### PR TITLE
docs/tutorial/2026: pin QEMU v10.2.0 for ch1 and ch2

### DIFF
--- a/docs/tutorial/2026/ch1/qemu-debug.md
+++ b/docs/tutorial/2026/ch1/qemu-debug.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 下面介绍几种常用的 QEMU 调试手段，或调试 QEMU，或调试客户机系统。
 
 !!! tip "概览"

--- a/docs/tutorial/2026/ch1/qemu-init.md
+++ b/docs/tutorial/2026/ch1/qemu-init.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn) [@Plucky923](https://github.com/Plucky923)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 对一个软件源码建立最直观印象的方法，就是观测它的初始化流程。QEMU 是一个 C 为主体的项目，所以理所当然我们要从 main 函数开始追踪。
 
 以 qemu-system-riscv64 为例，我们使用如下命令启动：

--- a/docs/tutorial/2026/ch1/qemu-mr.md
+++ b/docs/tutorial/2026/ch1/qemu-mr.md
@@ -5,6 +5,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 !!! tip "概览"
 
     - 地址空间与 MemoryRegion 的抽象与分工

--- a/docs/tutorial/2026/ch1/qemu-qom.md
+++ b/docs/tutorial/2026/ch1/qemu-qom.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 !!! tip "概览"
 
     - QOM 的基本概念与面向对象特性

--- a/docs/tutorial/2026/ch1/qemu-startup-param.md
+++ b/docs/tutorial/2026/ch1/qemu-startup-param.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 QEMU 是一款功能强大的开源虚拟化和仿真软件，支持多种处理器架构（x86、ARM、RISC-V、MIPS、Loongarch 等）。通过 QEMU，开发者可以在不同的硬件平台上测试操作系统、运行应用程序、进行内核开发和调试。
 
 本章节将聚焦 QEMU 常用启动参数，以启动 OpenEuler RISC-V 系统为实例，重点讲解主板选型、CPU 配置、设备添加等核心操作，进而介绍如何精准查找适配自身需求的 QEMU 启动参数，抛砖引玉助力读者掌握相关应用方法。

--- a/docs/tutorial/2026/ch1/vm-history.md
+++ b/docs/tutorial/2026/ch1/vm-history.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn) [@Plucky923](https://github.com/Plucky923)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 QEMU 是一个成熟的虚拟化软件和模拟器，虽然 QEMU 已经发展了二十多年，但是虚拟化技术的诞生，还要往前追溯很远。在这一章，我们将回顾虚拟化技术的发展历史及常见的应用场景，你可以选择感兴趣的片段进行阅读，希望可以给你带来一些启发。
 
 !!! tip "概览"

--- a/docs/tutorial/2026/ch2/qemu-clock.md
+++ b/docs/tutorial/2026/ch2/qemu-clock.md
@@ -4,7 +4,11 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
-QEMU 的“时钟系统”包含两套相关但不同的机制：一套是驱动定时器与主循环的 **QEMUClock/QEMUTimer**，另一套是建模硬件时钟树的 **Clock QOM 对象**。理解它们的职责边界，是写出稳定设备模型和掌握时间推进逻辑的关键。
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
+QEMU 的”时钟系统”包含两套相关但不同的机制：一套是驱动定时器与主循环的 **QEMUClock/QEMUTimer**，另一套是建模硬件时钟树的 **Clock QOM 对象**。理解它们的职责边界，是写出稳定设备模型和掌握时间推进逻辑的关键。
 
 一句话总结：**QEMUClock 决定“时间怎么走”，Clock 决定“频率怎么分发”。**
 

--- a/docs/tutorial/2026/ch2/qemu-cpu-model.md
+++ b/docs/tutorial/2026/ch2/qemu-cpu-model.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn) [@Plucky923](https://github.com/Plucky923)
 
+!!! info “QEMU 版本”
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 在 QEMU 中理解或新增一个 RISC-V CPU 型号，最好不要把注意力只放在某一个文件上。按照源码实现，主要涉及下面 4 个内容：
 
 - QOM 类型系统：CPU 作为什么类型注册到 QEMU 对象模型中。
@@ -15,7 +19,7 @@ RISC-V 这套实现的核心结构有四个：
 
 - `RISCVCPU`：具体 CPU 实例，对应一个 hart。
 - `RISCVCPUClass`：CPU 类型对应的类对象，其中保存着该型号的默认定义。
-- `RISCVCPUDef`：某个 CPU 型号的默认“蓝图”。
+- `RISCVCPUDef`：某个 CPU 型号的默认”蓝图”。
 - `RISCVCPUConfig`：扩展开关和数值型配置项，最终保存在 CPU 实例里。
 
 !!! tip "概览"

--- a/docs/tutorial/2026/ch2/qemu-gpgpu-kernel.md
+++ b/docs/tutorial/2026/ch2/qemu-gpgpu-kernel.md
@@ -4,7 +4,11 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
-GPGPU 的“算子”通常对应 GPU 端的 kernel。本文从 kernel 下发与执行的通用流程切入，再结合 QEMU 的 system mode 解释如何模拟 Guest OS、PCIe 设备与 GPGPU 模型，最后给出“算子下发执行”的可实现路径。
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
+GPGPU 的”算子”通常对应 GPU 端的 kernel。本文从 kernel 下发与执行的通用流程切入，再结合 QEMU 的 system mode 解释如何模拟 Guest OS、PCIe 设备与 GPGPU 模型，最后给出“算子下发执行”的可实现路径。
 
 !!! tip "概览"
 

--- a/docs/tutorial/2026/ch2/qemu-gpgpu.md
+++ b/docs/tutorial/2026/ch2/qemu-gpgpu.md
@@ -4,7 +4,11 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
-GPGPU（General-Purpose GPU）把 GPU 从“图形渲染器”变成“通用并行计算器”。它靠大量并行线程隐
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
+GPGPU（General-Purpose GPU）把 GPU 从”图形渲染器”变成”通用并行计算器”。它靠大量并行线程隐
 藏内存延迟，用吞吐量换取响应时间，是与 CPU 完全不同的设计哲学。
 
 本文的目的在于提供一个理解 GPGPU 的全局视角与知识背景，但重心是关注如何在 QEMU 上集成或建模

--- a/docs/tutorial/2026/ch2/qemu-hw.md
+++ b/docs/tutorial/2026/ch2/qemu-hw.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 我们以 PL011 串口为例，说明 QEMU 外设建模的主要方法。选择 PL011 作为讲解对象的原因是，这个设备同样实现了 Rust 版本，方便大家学习，同时，PL011 也是我们专业阶段实验 G233 主板所使用的串口设备。
 
 PL011 的实现位于 `hw/char/pl011.c`，状态定义在 `include/hw/char/pl011.h`。它是一个典型的 SysBus 设备：通过 QOM 注册类型、用状态结构描述寄存器与 FIFO、用 MMIO 回调响应访问、并通过 IRQ 线连接到平台中断控制器（如 GIC）。

--- a/docs/tutorial/2026/ch2/qemu-insn.md
+++ b/docs/tutorial/2026/ch2/qemu-insn.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 本章介绍 QEMU 如何模拟客户机指令，主要从指令译码与指令行为实现两个方面展开。
 
 !!! tip "概览"

--- a/docs/tutorial/2026/ch2/qemu-intr.md
+++ b/docs/tutorial/2026/ch2/qemu-intr.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 本文以 QEMU system mode + TCG 为背景，梳理“模拟 CPU 的中断/异常”处理链路。我们关注两个问题：中断/异常如何进入 CPU 执行循环？架构相关的处理逻辑在哪里落地？
 
 一句话总结：**QEMU 会在 TB 边界检查中断和异常，并把真正的处理交给目标架构的回调**。

--- a/docs/tutorial/2026/ch2/qemu-machine.md
+++ b/docs/tutorial/2026/ch2/qemu-machine.md
@@ -4,7 +4,11 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
-QEMU 里的“主板”对应 machine model（机型）。它不是一颗 CPU，也不是单个外设，而是**把 CPU 拓扑、内存布局、总线、外设、中断路由、固件入口**统一编排起来的一层“板级模型”。
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
+QEMU 里的”主板”对应 machine model（机型）。它不是一颗 CPU，也不是单个外设，而是**把 CPU 拓扑、内存布局、总线、外设、中断路由、固件入口**统一编排起来的一层“板级模型”。
 
 !!! tip "概览"
 

--- a/docs/tutorial/2026/ch2/qemu-multi-core.md
+++ b/docs/tutorial/2026/ch2/qemu-multi-core.md
@@ -4,7 +4,11 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
-QEMU 在系统模式下模拟“多核 CPU”时，核心思想是：**把每个逻辑 CPU 抽象成一个 vCPU，并为其建立执行上下文与线程模型**。
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
+QEMU 在系统模式下模拟”多核 CPU”时，核心思想是：**把每个逻辑 CPU 抽象成一个 vCPU，并为其建立执行上下文与线程模型**。
 
 !!! tip "概览"
 

--- a/docs/tutorial/2026/ch2/qemu-pcie.md
+++ b/docs/tutorial/2026/ch2/qemu-pcie.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 PCIe 是现代系统里最常见的外设互连总线之一。QEMU 在系统模式下会完整模拟 PCIe 拓扑、配置空间、BAR 映射、中断以及扩展能力，这让我们可以用纯软件复现“发现设备—配置资源—运行驱动”的真实流程。
 
 本文给出一个通俗的全局视角：PCIe 在 QEMU 中被拆成哪些层次？配置空间如何读写？BAR 如何映射？以及如何基于这些机制建模一个 PCIe 设备。

--- a/docs/tutorial/2026/ch2/qemu-rust-ffi.md
+++ b/docs/tutorial/2026/ch2/qemu-rust-ffi.md
@@ -4,7 +4,11 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
-Rust for QEMU 的核心目标不是“重写 QEMU”，而是让 Rust 设备与现有 C 基础设施协同工作。FFI（Foreign Function Interface）就是这套协同机制的中枢：它既要把 C API 暴露给 Rust，也要把 Rust 设备注册为 QOM 对象、回调与设备入口函数。本文基于将梳理 Rust FFI 在 QEMU 上的实现路径与关键机制。
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
+Rust for QEMU 的核心目标不是”重写 QEMU”，而是让 Rust 设备与现有 C 基础设施协同工作。FFI（Foreign Function Interface）就是这套协同机制的中枢：它既要把 C API 暴露给 Rust，也要把 Rust 设备注册为 QOM 对象、回调与设备入口函数。本文基于将梳理 Rust FFI 在 QEMU 上的实现路径与关键机制。
 
 !!! tip "概览"
 

--- a/docs/tutorial/2026/ch2/qemu-rust-model.md
+++ b/docs/tutorial/2026/ch2/qemu-rust-model.md
@@ -4,7 +4,11 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
-Rust for QEMU 的目标是让 Rust 设备与现有 C 基础设施协同工作。本文聚焦“如何用 Rust 建模外设”，并以 I2C 设备与 GPIO 设备（PCF8574）作为示例，说明从构建接入到设备行为实现的完整链路，同时补充 SysBus 的 Rust 封装要点。
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
+Rust for QEMU 的目标是让 Rust 设备与现有 C 基础设施协同工作。本文聚焦”如何用 Rust 建模外设”，并以 I2C 设备与 GPIO 设备（PCF8574）作为示例，说明从构建接入到设备行为实现的完整链路，同时补充 SysBus 的 Rust 封装要点。
 
 !!! tip "概览"
 

--- a/docs/tutorial/2026/ch2/qemu-rust-test.md
+++ b/docs/tutorial/2026/ch2/qemu-rust-test.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 本文介绍如何基于 Rust for QEMU 框架编写单元测试。重点是测试入口、写法模式、绑定生成依赖，以及设备代码的可测性拆分策略。
 
 !!! tip "概览"

--- a/docs/tutorial/2026/ch2/qemu-softmmu.md
+++ b/docs/tutorial/2026/ch2/qemu-softmmu.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 QEMU 的系统模式（system mode）需要完整模拟一台计算机——包括 CPU、内存和外设。在真实硬件上，CPU 通过 MMU（Memory Management Unit）和 TLB（Translation Lookaside Buffer）完成虚拟地址到物理地址的翻译，然后由物理地址决定这次访问落到 DRAM 还是某个外设的寄存器上。QEMU 要在纯软件层面复现这套机制，这就是 SoftMMU 存在的理由——soft 意味着"用软件实现"，而非依赖宿主机的硬件 MMU。
 
 与之对应的 user mode 不需要操心这些：它只模拟用户态指令，客户机进程的内存直接通过 `mmap()` 映射到宿主机地址空间，地址翻译交给宿主机的 OS 和硬件 MMU 处理。两种模式在内存管理上的差异，本质上就是"要不要自己实现 MMU"这一个问题。

--- a/docs/tutorial/2026/ch2/qemu-tcg.md
+++ b/docs/tutorial/2026/ch2/qemu-tcg.md
@@ -4,6 +4,10 @@
 
     - 作者：[@zevorn](https://github.com/zevorn) [@Plucky923](https://github.com/Plucky923)
 
+!!! info "QEMU 版本"
+
+    本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
+
 QEMU 支持多种 accel，但大体可以分为两种：指令模拟技术（TCG）、虚拟化技术（KVM、HVF）等。QEMU 有两种主要的运行模式：System mode 模拟整个机器（CPU、内存和虚拟设备）以运行客户机操作系统；User mode 则允许在一个 CPU 架构上运行为另一个 CPU 编译的用户态进程，此时 CPU 始终被模拟，主要支持 Linux 用户态程序。
 
 !!! tip "概览"


### PR DESCRIPTION
## Summary
- 为 2026 在线讲义基础阶段（ch1，6 篇）和专业阶段（ch2，14 篇）的每篇文章添加 QEMU 版本标注
- 固定使用 QEMU **v10.2.0**（tag: `v10.2.0`，commit: `75eb8d57c6b9`）作为参考版本

## Test plan
- [x] `make serve` 本地预览，确认所有 info 卡片正常渲染
- [x] 检查 ch1/ch2 每篇文章顶部均有版本标注