### PR TITLE
docs/tutorial/ch2: fix admonition quote in qemu-cpu-model

### DIFF
--- a/docs/tutorial/2026/ch2/qemu-cpu-model.md
+++ b/docs/tutorial/2026/ch2/qemu-cpu-model.md
@@ -4,7 +4,7 @@
 
     - 作者：[@zevorn](https://github.com/zevorn) [@Plucky923](https://github.com/Plucky923)
 
-!!! info“QEMU 版本”
+!!! info "QEMU 版本"
 
     本文基于 QEMU **v10.2.0**（tag: [`v10.2.0`](https://gitlab.com/qemu-project/qemu/-/tags/v10.2.0)，commit: `75eb8d57c6b9`）。
 


### PR DESCRIPTION
## Summary
- 修复 `qemu-cpu-model.md` 中 `!!! info` 卡片标题的引号问题
- autocorrect CI 将 ASCII 直引号替换为中文弯引号，导致 admonition 卡片渲染失效

## Test plan
- [ ] `make serve` 本地预览，确认 qemu-cpu-model 页面的 info 卡片正常渲染