### PR TITLE
docs/tutorial/ch0: add Rust dev env section with riscv64-softmmu

### DIFF
--- a/docs/tutorial/2026/ch0/index.md
+++ b/docs/tutorial/2026/ch0/index.md
@@ -69,7 +69,7 @@
 [qemu-devel-email-link]: ../../../blogs/misc/qemu-devel-email.md
 [qemu-build-link]: https://qemu.readthedocs.io/en/v10.0.3/devel/build-system.html
 [qemu-c-env-link]: https://qemu.readthedocs.io/en/v10.0.3/devel/build-environment.html
-[qemu-rust-env-link]: https://hust-open-atom-club.github.io/rust-for-qemu-insides/articles/ch0/02-compile-and-debug/
+[qemu-rust-env-link]: qemu-dev-env.md#rust-开发环境配置可选
 [qemu-dev-env-local-link]: qemu-dev-env.md
 [gpgpu-resources-local-link]: gpgpu-resources.md
 [gpu-history-local-link]: gpu-history.md

--- a/docs/tutorial/2026/ch0/qemu-dev-env.md
+++ b/docs/tutorial/2026/ch0/qemu-dev-env.md
@@ -198,6 +198,7 @@ gdb --args ./build/qemu-system-riscv64 -machine virt -nographic -bios none
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
 cargo install bindgen-cli
 ```
 

--- a/docs/tutorial/2026/ch0/qemu-dev-env.md
+++ b/docs/tutorial/2026/ch0/qemu-dev-env.md
@@ -206,7 +206,7 @@ cargo install bindgen-cli
 ```bash
 mkdir build-rust && cd build-rust
 ../configure \
-    --target-list="aarch64-softmmu,x86_64-softmmu,riscv64-softmmu" \
+    --target-list=riscv64-softmmu \
     --enable-rust \
     --enable-slirp
 ```

--- a/docs/tutorial/2026/ch0/qemu-dev-env.md
+++ b/docs/tutorial/2026/ch0/qemu-dev-env.md
@@ -192,6 +192,29 @@ gdb --args ./build/qemu-system-riscv64 -machine virt -nographic -bios none
 
     调试技巧的详细介绍请参考基础阶段的 [常用调试方法](../ch1/qemu-debug.md)。
 
+## Rust 开发环境配置（可选）
+
+如需启用 QEMU 的 Rust 支持（用于 Rust 设备模型开发），需要额外安装 Rust 工具链和 bindgen：
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+cargo install bindgen-cli
+```
+
+配置时添加 `--enable-rust` 并确保 `target-list` 包含 `riscv64-softmmu`：
+
+```bash
+mkdir build-rust && cd build-rust
+../configure \
+    --target-list="aarch64-softmmu,x86_64-softmmu,riscv64-softmmu" \
+    --enable-rust \
+    --enable-slirp
+```
+
+!!! tip "更多信息"
+
+    Rust FFI 机制的详细介绍请参考专业阶段的 [Rust FFI](../ch2/qemu-rust-ffi.md)。
+
 ## 附录：CNB qemu-lab 云原生一键开发
 
 如果你不想花时间在本地配置环境，可以使用 CNB（Cloud Native Build）平台提供的云端开发环境。`qemu-lab` 项目已经预配置了完整的 QEMU 编译环境，开箱即用。


### PR DESCRIPTION
## 关联章节/文件
- 文档路径：`docs/tutorial/2026/ch0/qemu-dev-env.md`
- 文档路径：`docs/tutorial/2026/ch0/index.md`

## 修改类型
- [x] 内容补充

## 修改描述
- 外部链接「搭建 QEMU Rust 开发环境」缺少 RISC-V 架构的 target 指定（`riscv64-softmmu`）
- 在 `qemu-dev-env.md` 新增「Rust 开发环境配置（可选）」章节，包含正确的 configure 命令（含 `riscv64-softmmu`）
- 将 `index.md` 中的 Rust 环境链接从外部站点改为指向本地新增章节

Closes #23

## 本地验证
- [x] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [x] 已执行 `zensical serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观

## 附加说明 (可选)
原外部链接 (hust-open-atom-club.github.io) 中的 configure 命令 target-list 缺少 `riscv64-softmmu`，且该站点非本仓库可控。因此选择在本地文档中补充完整的 Rust 开发环境配置章节。