### PR TITLE
docs/exercise/stage1: update upstream repo URL to classroom template

### DIFF
--- a/docs/exercise/2026/stage1/cpu/cpu-exper-manual.md
+++ b/docs/exercise/2026/stage1/cpu/cpu-exper-manual.md
@@ -49,9 +49,13 @@ git clone git@github.com:gevico/qemu-camp-2026-exper-<你的 github 用户名>.g
 第四步，添加上游远程仓库，用于同步上游代码变更：
 
 ```bash
-git remote add upstream git@github.com:gevico/qemu-camp-2026-exper.git
+git remote add upstream git@github.com:gevico/gevico-classroom-qemu-camp-2026-exper-qemu-camp-2026-exper.git
 git pull upstream main --rebase
 ```
+
+!!! note "提示"
+
+    使用 SSH 地址需要在 GitHub 上配置 SSH Key，请参考 [GitHub SSH Key 配置指南](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh)。
 
 第五步，配置并编译：
 

--- a/docs/exercise/2026/stage1/gpu/gpu-exper-manual.md
+++ b/docs/exercise/2026/stage1/gpu/gpu-exper-manual.md
@@ -39,9 +39,13 @@ git clone git@github.com:gevico/qemu-camp-2026-exper-<你的 github 用户名>.g
 第四步，添加上游远程仓库，用于同步上游代码变更：
 
 ```bash
-git remote add upstream git@github.com:gevico/qemu-camp-2026-exper.git
+git remote add upstream git@github.com:gevico/gevico-classroom-qemu-camp-2026-exper-qemu-camp-2026-exper.git
 git pull upstream main --rebase
 ```
+
+!!! note "提示"
+
+    使用 SSH 地址需要在 GitHub 上配置 SSH Key，请参考 [GitHub SSH Key 配置指南](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh)。
 
 第五步，配置并编译：
 

--- a/docs/exercise/2026/stage1/index.md
+++ b/docs/exercise/2026/stage1/index.md
@@ -28,9 +28,13 @@ git clone git@github.com:gevico/qemu-camp-2026-exper-<你的 github 用户名>.g
 **第三步**，添加上游远程仓库，用于同步上游代码变更：
 
 ```bash
-git remote add upstream git@github.com:gevico/qemu-camp-2026-exper.git
+git remote add upstream git@github.com:gevico/gevico-classroom-qemu-camp-2026-exper-qemu-camp-2026-exper.git
 git pull upstream main --rebase
 ```
+
+!!! note "提示"
+
+    使用 SSH 地址需要在 GitHub 上配置 SSH Key，请参考 [GitHub SSH Key 配置指南](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh)。
 
 ## 环境搭建
 

--- a/docs/exercise/2026/stage1/rust/rust-exper-manual.md
+++ b/docs/exercise/2026/stage1/rust/rust-exper-manual.md
@@ -39,9 +39,13 @@ git clone git@github.com:gevico/qemu-camp-2026-exper-<你的 github 用户名>.g
 第四步，添加上游远程仓库，用于同步上游代码变更：
 
 ```bash
-git remote add upstream git@github.com:gevico/qemu-camp-2026-exper.git
+git remote add upstream git@github.com:gevico/gevico-classroom-qemu-camp-2026-exper-qemu-camp-2026-exper.git
 git pull upstream main --rebase
 ```
+
+!!! note "提示"
+
+    使用 SSH 地址需要在 GitHub 上配置 SSH Key，请参考 [GitHub SSH Key 配置指南](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh)。
 
 第五步，配置并编译：
 

--- a/docs/exercise/2026/stage1/soc/g233-exper-manual.md
+++ b/docs/exercise/2026/stage1/soc/g233-exper-manual.md
@@ -43,9 +43,13 @@ git clone git@github.com:gevico/qemu-camp-2026-exper-<你的 github 用户名>.g
 第四步，添加上游远程仓库，用于同步上游代码变更：
 
 ```bash
-git remote add upstream git@github.com:gevico/qemu-camp-2026-exper.git
+git remote add upstream git@github.com:gevico/gevico-classroom-qemu-camp-2026-exper-qemu-camp-2026-exper.git
 git pull upstream main --rebase
 ```
+
+!!! note "提示"
+
+    使用 SSH 地址需要在 GitHub 上配置 SSH Key，请参考 [GitHub SSH Key 配置指南](https://docs.github.com/zh/authentication/connecting-to-github-with-ssh)。
 
 第五步，配置并编译：
 


### PR DESCRIPTION
## Summary
- Update upstream repo URL from `qemu-camp-2026-exper` to `gevico-classroom-qemu-camp-2026-exper-qemu-camp-2026-exper` across all stage1 experiment manuals
- Add SSH Key configuration hint (admonition) after the upstream setup command

## Test plan
- [x] Verify the upstream URL is correct in all 5 files
- [x] Verify the SSH Key admonition renders correctly in MkDocs