### PR TITLE
docs/exercise/2026: fix the error test cmd for g233-exper-manual.md

### DIFF
--- a/docs/exercise/2026/stage1/soc/g233-exper-manual.md
+++ b/docs/exercise/2026/stage1/soc/g233-exper-manual.md
@@ -83,7 +83,7 @@ git push origin main
 本地运行全部测题的方式：
 
 ```bash
-make check-gevico-qtest
+make -f Makefile.camp test-soc
 ```
 
 SoC 方向全部测题通过的情况下，你会看到如下输出：


### PR DESCRIPTION
change `make check-gevico-qtest`  to `make -f Makefile.camp test-soc`

## 关联章节/文件
<!-- 请填写您修改的文档路径或代码文件路径，例如： -->
- 文档路径：`docs/exercise/2026/stage1/soc/g233-exper-manual.md`

## 修改类型
<!-- 请选择一项或多项，并用 [x] 标记 -->
- [ ] 内容补充
- [ ] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [x] 其他 (请说明): 错误修正

## 修改描述
<!-- 请简要描述您本次修改的主要内容和原因 -->
- 当前SoC的测试方式已经改为`make -f Makefile.camp test-soc`，但是文档内还是2025年的已移除的Make目标

## 本地验证
<!-- 请确保您已在本地完成以下检查 -->
- [x] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [x] 已执行 `zensical serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观