### PR TITLE
docs/tutorial/2026/ch0: add camp FAQ digest

### DIFF
--- a/docs/tutorial/2026/ch0/index.md
+++ b/docs/tutorial/2026/ch0/index.md
@@ -60,6 +60,14 @@
 
     [开源社区实践: 参与上游贡献与补丁解读][qemu-unstream-link]
 
+### 答疑速查
+
+!!! question "常见问答"
+
+    [训练营常见问答（FAQ）][qemu-camp-faq-link]
+
+    汇总导学阶段群内高频提问：环境搭建、OpenCamp 与 Classroom、专业阶段实验、训练营组织与答疑。
+
 
 [qemu-cnb-link]: ../../../blogs/misc/qemu-cnb-dev.md
 [learning-c-camp-link]: https://opencamp.ai/C/camp/2025/register?code=cMJBju7dp5cTR
@@ -79,3 +87,4 @@
 [linux-ima-link]: https://ima.qq.com/wiki/?shareId=361fb581e4ddf2c0d7d4e3ba062b66df294e9b13976530804bd75a6c138d58a8
 [risc-sim-link]: https://www.bilibili.com/video/BV12Z4y1c74c
 [qemu-camp-2025-link]: https://www.bilibili.com/video/BV1J84VzsEJg/
+[qemu-camp-faq-link]: qemu-camp-faq.md

--- a/docs/tutorial/2026/ch0/qemu-camp-faq.md
+++ b/docs/tutorial/2026/ch0/qemu-camp-faq.md
@@ -1,0 +1,202 @@
+# 训练营常见问答（FAQ）
+
+!!! note "主要贡献者"
+
+    - 整理：[@zevorn](https://github.com/zevorn)
+
+本页汇总 QEMU 训练营 2026 导学阶段群聊中出现频率较高的问题与解答，便于新学员快速定位答案。问题来源为 QQ 群 `1032308510` 的值周答疑汇总，按四个板块归档共性议题。
+
+!!! tip "如何使用这份 FAQ"
+
+    - 遇到问题时，先按下面四个板块快速定位：环境搭建、OpenCamp 与 Classroom、专业阶段实验、训练营组织与答疑。
+    - 答案中的 **Ref.** 指向讲义内对应章节或群内答疑时间，可按图索骥回到原文。
+    - 若问题未收录或已过时，欢迎向 [`gevico/qemu-camp-tutorial`](https://github.com/gevico/qemu-camp-tutorial) 提交 PR 更新本文。
+
+## § 01 环境搭建
+
+!!! question "Q01 · CNB 工作区每次打开都要重下源码？"
+
+    **问题**：CNB 云原生开发环境每次打开都要重新下载 QEMU 源码吗？上次下载的代码、构建产物还在吗？
+
+    **解答**：
+
+    1. CNB 工作区目前不提供用户自定义的持久化存储卷，每次新开环境确实会丢失本地修改。
+    2. 推荐做法：Fork `qemu-lab` 仓库，把 QEMU 源码作为 submodule 引入自己的仓库，每次启动自动拉取。
+    3. 或直接使用训练营专业阶段实验仓库 `qemu-camp-2026-exper`，内置统一的 `make` 命令。
+    4. 关键：所有修改必须及时 `git commit && git push` 到远端，关闭网页 IDE 即丢失。
+
+    **Ref.** `docs/blogs/misc/qemu-cnb-dev.md` · `docs/tutorial/2026/ch0/qemu-dev-env.md#附录：CNB qemu-lab 云原生一键开发`
+
+!!! question "Q02 · Mac 上能直接编译 QEMU 吗？"
+
+    **问题**：Mac 上能不能直接编译 QEMU？我想用 Rust 写 QEMU 代码。
+
+    **解答**：
+
+    1. 不推荐在 macOS 上直接编译 QEMU — 虽官方支持，但工具链/依赖坑多，复现成本高。
+    2. 推荐两条路：① `Ubuntu 22.04+` / `WSL2` 本地环境；② CNB 云原生开发环境（零配置）。
+    3. QEMU 是 C 与 Rust 混合编译，Rust 支持由内置 `meson + bindgen` 完成，不需要额外做 wasm。
+    4. 从零搭建开发环境请翻阅 [QEMU 编译开发环境搭建](qemu-dev-env.md)。
+
+    **Ref.** `docs/tutorial/2026/ch0/qemu-dev-env.md#系统要求`
+
+!!! question "Q03 · C 与 Rust 文档里的 target-list 不一致？"
+
+    **问题**：C 语言和 Rust 开发环境搭建时配置的 target-list 架构不一样，需要统一吗？
+
+    **解答**：
+
+    1. 训练营最终只需要 `riscv64-softmmu` 这一个 target。
+    2. Rust 环境文档里写的 `aarch64` / `x86_64` 组合，是 Rust 工具链示例的默认值，而非训练营要求。
+    3. 建议统一为：`--target-list=riscv64-softmmu --enable-slirp`。
+    4. 欢迎向讲义仓库 `gevico/qemu-camp-tutorial` 提交 PR 统一文档说明，成为贡献者。
+
+    **Ref.** `docs/tutorial/2026/ch0/qemu-dev-env.md#配置编译选项`
+
+!!! question "Q04 · CNB fork 时要求填写“组织”填什么？"
+
+    **问题**：CNB fork 仓库时要求填组织，该填什么？
+
+    **解答**：
+
+    1. 在 CNB 上 fork 时，若需要组织，请创建一个属于自己的个人组织（例如以昵称 / GitHub ID 命名）。
+    2. 直接 fork 到个人账号在部分场景下会有权限限制，放自建组织里后续协作也更方便。
+    3. 注意：GitHub Classroom 邀请链接会自动 fork 到 `gevico` 组织下，不需要自己选。
+
+    **Ref.** `docs/exercise/2026/stage1/index.md#获取实验仓库`
+
+## § 02 OpenCamp 与 Classroom
+
+!!! question "Q05 · Action 已跑，OpenCamp 为何零分？"
+
+    **问题**：GitHub Action 都跑过了，OpenCamp 成绩为什么不显示？
+
+    **解答**：
+
+    1. 需要在 OpenCamp 个人中心绑定 GitHub 用户名 — 填 `username`，不是主页链接。
+    2. 未绑定 GitHub 时，CI 跑再多次也不会上分。
+    3. 绑定后需要再 push 一次触发 Action，或到 Actions 页面手动 Re-run。
+    4. 仍然 0 分时：确认 CI 真的绿了，并检查是否生成 `test_results_summary.json`。
+
+    **Ref.** `docs/exercise/2026/stage0/index.md` · 群内 FAQ
+
+!!! question "Q06 · Classroom 邀请链接 500 错误怎么办？"
+
+    **问题**：Classroom 邀请链接点了之后 500 Internal Server Error / something went wrong。
+
+    **解答**：
+
+    1. GitHub Classroom 偶发性故障，通常等 1–5 分钟刷新即可恢复。
+    2. 若之前误取消了邀请导致无法再次进入，请联系讲师重新下发邀请链接。
+    3. 进不去 Classroom 时可以先到 <https://github.com/orgs/gevico/repositories> 用自己的 GitHub ID 搜索仓库，确认是否已经生成。
+
+    **Ref.** 群内通知（04-10 15:25）
+
+!!! question "Q07 · OpenCamp 的 secret 在哪里获取？"
+
+    **问题**：OpenCamp 的 secret 怎么获取？
+
+    **解答**：
+
+    1. 不需要自己配 secret — Classroom 给你 fork 的仓库里 CI 已经配置好。
+    2. 直接 `git push` 到自己的仓库即可自动评分。
+    3. 如果确有手动需要：OpenCamp 个人中心有 API Token 入口，但训练营流程用不到。
+
+    **Ref.** 群内回答（04-10 12:54）
+
+## § 03 专业阶段实验
+
+!!! question "Q08 · 四个方向都必须做吗？Rust 呢？"
+
+    **问题**：专业阶段是选做吗？四个方向都要做吗？Rust 项目必须做吗？
+
+    **解答**：
+
+    1. 专业阶段共 `4` 个方向：CPU、SoC、GPGPU、Rust；选择任一方向满分通过即可晋级。
+    2. 鼓励多方向尝试，但不是必须。
+    3. 进入项目阶段的条件：① 任一方向满分；② 贡献一篇总结博客。
+    4. 博客路径：Fork `qemu-camp-tutorial` → `docs/blogs/2026/qemu-camp-2026-<你的 github id>.md` → 提交 PR。
+
+    **Ref.** `docs/exercise/2026/stage1/index.md#晋级项目阶段`
+
+!!! question "Q09 · git pull upstream 报 multiple branches？"
+
+    **问题**：`git pull upstream main --rebase` 报错 _Cannot rebase onto multiple branches_。
+
+    **解答**：
+
+    1. 远程仓库地址错了，请使用 `gevico/qemu-camp-2026-exper`（旧地址/克隆路径可能指向 Classroom 自动生成的长名仓库）。
+    2. 正确命令：`git remote add upstream git@github.com:gevico/qemu-camp-2026-exper.git`（讲义已更新）。
+    3. 第四步非必须，本地能 build/test 即可，后续需要同步上游修复时再执行。
+    4. 如仍报错，先 `git branch -a` 确认当前 main 分支是否存在，再重试 rebase。
+
+    **Ref.** `docs/exercise/2026/stage1/gpu/gpu-exper-manual.md` · 群内答疑（04-14 19:40）
+
+!!! question "Q10 · Ubuntu 20.04 能编译 GPU 实验吗？"
+
+    **问题**：GPU 实验编译报错，Ubuntu 20.04 能用吗？是否只能用 CNB？
+
+    **解答**：
+
+    1. 官方推荐 `Ubuntu 22.04 LTS` 及以上。20.04 上 glib / pixman 版本偏老，容易导致 meson 报错。
+    2. GPU 方向暂时没有官方 CNB 镜像，需要自己构建环境。
+    3. 可以用 docker 起一个 `ubuntu:24.04` 容器，按 `gpu-exper-manual.md` 的依赖清单安装。
+    4. 环境搞通后欢迎把流程补充到讲义仓库，成为新的贡献者。
+
+    **Ref.** `docs/exercise/2026/stage1/gpu/gpu-exper-manual.md#环境搭建`
+
+!!! question "Q11 · build 目录下测题 stdout 不显示？"
+
+    **问题**：build 目录下测题的 stdout 都看不见，怎么让它输出？
+
+    **解答**：
+
+    1. 批量跑测时 stdout 被重定向到 log 文件，默认不在终端打印。
+    2. 在 `build/tests/gevico/` 下会有 log / out 文件，`cat` 即可查看。
+    3. 单独调试某题时，直接用 `qos-test -p 路径` 单独运行，终端会实时输出。
+    4. 这是一个优化点 — 欢迎提 PR 让单题调试默认打印 stdout。
+
+    **Ref.** `docs/exercise/2026/stage1/gpu/gpu-exper-manual.md#测评验收`
+
+## § 04 训练营组织与答疑
+
+!!! question "Q12 · 训练营的时间线、阶段安排？"
+
+    **问题**：训练营的时间线、阶段安排是怎样的？
+
+    **解答**：
+
+    1. 共 16 周：`2026-04-05` 开营，`2026-08-09` 结营。
+    2. `04/06 – 04/26` 导学阶段。
+    3. `04/27 – 05/10` 基础阶段 · `05/11 – 06/14` 专业阶段。
+    4. `06/28` 选题会 · `06/29 – 08/08` 项目阶段。
+    5. 每周四 20:00–20:30 在线交流会，腾讯会议 `449-3341-6333`。
+
+    **Ref.** `docs/tutorial/2026/ch0` · 群内日程
+
+!!! question "Q13 · 项目阶段当本科毕设够吗？"
+
+    **问题**：项目阶段的项目当本科毕设够吗？有什么参考？
+
+    **解答**：
+
+    1. 够用 — 去年已有多位学员以项目阶段成果作为毕设 / 研究课题。
+    2. 参考：开营仪式回放 + 《2026 年课程内容介绍：四个阶段（六个实验、四个项目）》。
+    3. 进入项目阶段会有专属导师带队。
+    4. 方向包括：AI 加速硬件建模、CXLMemSim、hetGPU、machina（Rust QEMU 重写）等。
+
+    **Ref.** [bilibili BV1CSSQByEDB](https://www.bilibili.com/video/BV1CSSQByEDB) · <https://qemu.gevico.online/tutorial/2026/ch3>
+
+!!! question "Q14 · 如何把博客推送到讲义网站？"
+
+    **问题**：如何贡献博客？如何推送到讲义网站？
+
+    **解答**：
+
+    1. Fork `gevico/qemu-camp-tutorial` 仓库。
+    2. 在 `docs/blogs/2026/` 新建 `qemu-camp-2026-<你的 github id>.md`。
+    3. 按模板填写：背景介绍 / 专业阶段 / 总结；并同步更新 `mkdocs.yml` 导航。
+    4. PR 标题：`docs/blogs: add stage1 summary by <github id>`。
+    5. 审核合入后自动上站：<https://qemu.gevico.online/blogs/>。
+
+    **Ref.** `docs/exercise/2026/stage1/index.md#博客贡献流程`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
         - a. QEMU 开发环境搭建: tutorial/2026/ch0/qemu-dev-env.md
         - b. GPU 发展历史: tutorial/2026/ch0/gpu-history.md
         - c. GPGPU 学习资料: tutorial/2026/ch0/gpgpu-resources.md
+        - d. 训练营常见问答: tutorial/2026/ch0/qemu-camp-faq.md
       - 2. 基础阶段:
         - 本章导览: tutorial/2026/ch1/index.md
         - a. 虚拟技术历史: tutorial/2026/ch1/vm-history.md


### PR DESCRIPTION
## 关联章节/文件
- 新增：`docs/tutorial/2026/ch0/qemu-camp-faq.md`
- 更新：`docs/tutorial/2026/ch0/index.md`（新增「答疑速查」入口）
- 更新：`mkdocs.yml`（导学阶段新增 `d. 训练营常见问答` 导航项）

## 修改类型
- [x] 内容补充
- [ ] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述

为导学阶段新增一份 FAQ 速查页，沉淀 QQ 群 `1032308510` 本周（2026-04-09 ~ 04-16, Issue № 02）从 995 条消息、39 个原始提问中归档出的 14 个共性议题。按原始 PPT 的四个板块组织：

- § 01 环境搭建（Q1–Q4）：CNB 持久化、Mac 编译、target-list、fork 组织
- § 02 OpenCamp 与 Classroom（Q5–Q7）：成绩不显示、Classroom 500、secret 获取
- § 03 专业阶段实验（Q8–Q11）：四方向选做、rebase 报错、Ubuntu 版本、stdout 不显示
- § 04 训练营组织与答疑（Q12–Q14）：时间线、毕设参考、博客投稿流程

每条问答保留原题面、解答要点与 **Ref.** 引用（指向讲义对应章节或群内答疑时间），方便读者回到原文。并把入口同时挂到 ch0 `index.md` 的 `!!! question` 小节与 `mkdocs.yml` 侧栏导航，左栏与导读页均可找到。

### 关于图片

原始周报（`~/qbot/qemu-camp-weekly-report.html` / `.pdf`）使用纯 CSS + SVG 噪声纹理渲染，无任何 `<img>` 标签或外部栅格图，因此本次不涉及图片搬运。

## 本地验证
- [x] 已通过 `autocorrect --lint docs/tutorial/2026/ch0/qemu-camp-faq.md docs/tutorial/2026/ch0/index.md`（No issues found）
- [ ] 已执行 `zensical serve` 并在本地预览

## 附加说明

后续每周答疑纪要沉淀进本页即可，延伸阅读段落已预留「公众号周报」入口；若需要加入提问人署名或把 `!!! question` 改为普通 `##` 标题，欢迎 review 时指出。