### PR TITLE
docs/tutorial/2026/ch0: drop "§ NN" prefix from FAQ section titles

### DIFF
--- a/docs/tutorial/2026/ch0/qemu-camp-faq.md
+++ b/docs/tutorial/2026/ch0/qemu-camp-faq.md
@@ -12,7 +12,7 @@
     - 答案中的 **Ref.** 指向讲义内对应章节或群内答疑时间，可按图索骥回到原文。
     - 若问题未收录或已过时，欢迎向 [`gevico/qemu-camp-tutorial`](https://github.com/gevico/qemu-camp-tutorial) 提交 PR 更新本文。
 
-## § 01 环境搭建
+## 环境搭建
 
 !!! question "Q01 · CNB 工作区每次打开都要重下源码？"
 
@@ -65,7 +65,7 @@
 
     **Ref.** `docs/exercise/2026/stage1/index.md#获取实验仓库`
 
-## § 02 OpenCamp 与 Classroom
+## OpenCamp 与 Classroom
 
 !!! question "Q05 · Action 已跑，OpenCamp 为何零分？"
 
@@ -104,7 +104,7 @@
 
     **Ref.** 群内回答（04-10 12:54）
 
-## § 03 专业阶段实验
+## 专业阶段实验
 
 !!! question "Q08 · 四个方向都必须做吗？Rust 呢？"
 
@@ -158,7 +158,7 @@
 
     **Ref.** `docs/exercise/2026/stage1/gpu/gpu-exper-manual.md#测评验收`
 
-## § 04 训练营组织与答疑
+## 训练营组织与答疑
 
 !!! question "Q12 · 训练营的时间线、阶段安排？"
 


### PR DESCRIPTION
## 关联章节/文件
- 更新：`docs/tutorial/2026/ch0/qemu-camp-faq.md`

## 修改类型
- [ ] 内容补充
- [ ] 错别字/语句修正
- [x] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述

FAQ 四个板块的二级标题原先沿用了源 PPT 的版块编号（`§ 01 环境搭建` 等），在 MkDocs 渲染的侧栏 TOC / 锚点里并不能传达额外信息，反而读起来像遗留的幻灯片痕迹。本 PR 把四个 `## § NN XXX` 标题统一改成纯名称：

- `## § 01 环境搭建` → `## 环境搭建`
- `## § 02 OpenCamp 与 Classroom` → `## OpenCamp 与 Classroom`
- `## § 03 专业阶段实验` → `## 专业阶段实验`
- `## § 04 训练营组织与答疑` → `## 训练营组织与答疑`

其余正文（`Q01 · …` / `Q02 · …` 等问答标题，以及导览段里对四个板块名字的引用）保持不变。

## 本地验证
- [x] 已通过 `autocorrect --lint docs/tutorial/2026/ch0/qemu-camp-faq.md`（No issues found）
- [ ] 已执行 `zensical serve` 并在本地预览

## 附加说明

无新增依赖，纯文本级别的格式调整。