### PR TITLE
docs/exercise/2026/stage1: add advanced experiments to four directions

### DIFF
--- a/docs/exercise/2026/stage1/cpu/cpu-exper-manual.md
+++ b/docs/exercise/2026/stage1/cpu/cpu-exper-manual.md
@@ -314,6 +314,55 @@ Xg233ai 在 RISC-V custom-3 编码空间（opcode `0x7B`）内定义了 10 条 R
 | `test_vadd_inplace` | 验证目标与源地址相同时（原地操作）的正确性 |
 | `compare` | 比较软件实现与硬件指令结果 |
 
+## 进阶实验
+
+!!! note "说明"
+
+    进阶实验为开放题目，不计入 100 分基础测评，但会作为训练营评优与推荐的重要参考。鼓励在完成 10 道必做题后深入探索 TCG 前后端、翻译开销与多核语义。
+
+### 进阶实验一 Helper → 内联 TCG IR 重写
+
+基础实验中 Xg233ai 指令都通过 `gen_helper_*` 调用 C 实现，每次执行都要跨出翻译块、保存上下文、调用 helper、再返回。对计算密集型的循环而言，这笔开销相当可观。
+
+挑战目标：从 `vadd`、`vrelu`、`vscale` 三条指令中任选 1~2 条，完全用 `tcg_gen_*` 原语在 decodetree 回调里直接生成 TCG IR，**不再调用 helper**。
+
+参考方向：
+
+- 学习 `tcg/tcg-op.h` 提供的整数/向量原语；查阅 `target/riscv/insn_trans/trans_rvv.c.inc` 中 RVV 指令的内联实现。
+- 用 `tcg_gen_gvec_*` 接口把向量循环交给宿主机 SIMD 执行。
+- 对比两个版本在 `test-insn-*` 上的实测耗时（可用 `time`、`perf stat`、或 `-d in_asm,out_asm` 查看生成代码规模）。
+
+### 进阶实验二 基于 TCG Plugin 的翻译性能分析
+
+QEMU 提供了 TCG Plugin 机制，可以在不修改核心翻译器的前提下，挂载到每条 guest 指令/TB 的执行路径，用来做剖析。
+
+挑战目标：使用或扩展 `tests/tcg/plugins/` 下已有的 `hotblocks.c`、`insn.c`、`cache.c` 插件，对某个测题（推荐 `test-insn-gemm` 或 `test-insn-vdot`）输出以下数据：
+
+- Xg233ai 自定义指令 vs. 普通 RISC-V 指令的执行占比。
+- 翻译块（TB）命中率、链接命中率。
+- 每条 Xg233ai 指令在生成代码中的 host 指令条数。
+
+产出一份简短的分析报告，指出当前实现中开销最大的环节。
+
+### 进阶实验三 MTTCG 下的正确性与性能
+
+QEMU 默认的 TCG 后端是单线程模式（`thread=single`），对于 G233 这种多 hart 平台，可以启用多线程 TCG（`-accel tcg,thread=multi`）以获得真并行。
+
+挑战目标：
+
+- 让 10 道基础测题在 `-smp 4 -accel tcg,thread=multi` 下稳定通过（初次实现可能会暴露内存序、原子性相关的 bug）。
+- 分析 `gemm`、`dma` 这类涉及大量 load/store 的指令，在 MTTCG 下是否存在对同一 guest 物理页的并发访问问题，必要时使用 `tcg_gen_qemu_ld_*` 的正确内存顺序标志。
+- 记录多核相对单核的加速比。
+
+### 进阶实验四 为自定义指令加装性能计数器
+
+挑战目标：在自定义指令的实现中加入轻量级计数器（例如每条指令的执行次数、累计 cycle 估算值），可以是：
+
+- 通过 `CPURISCVState` 中新增字段，导出到一组自定义 CSR，测试程序运行完后读出并通过 semihosting 打印。
+- 或者挂载到 TCG Plugin 侧，按指令名聚合计数。
+
+最终目标是在不修改测题源码的前提下，产出一张「Xg233ai 指令使用热度表」，为后续硬件设计/软件优化提供数据支撑。
+
 [1]: https://qemu.readthedocs.io/en/v10.0.3/devel/build-environment.html
 [2]: https://github.com/riscv-collab/riscv-gnu-toolchain/releases/
 [3]: https://classroom.github.com/a/hwWFrmo_

--- a/docs/exercise/2026/stage1/gpu/gpu-exper-manual.md
+++ b/docs/exercise/2026/stage1/gpu/gpu-exper-manual.md
@@ -288,5 +288,40 @@ GPGPU 方向的全部实验围绕虚拟 PCIe 3D 加速器的设备建模与 SIMT
 
     E2M1 的 `f32 → e2m1` 转换是手写实现（非 softfloat），你需要理解 E2M1 的 4-bit 格式并用 FP32 位模式阈值实现正确的舍入与饱和逻辑。
 
+## 进阶实验
+
+!!! note "说明"
+
+    进阶实验为开放题目，不计入 100 分基础测评，但会作为训练营评优与推荐的重要参考。这两道题目在基础实验的 GPGPU 设备模型之上，向「软件栈」与「真实 cmodel 集成」两个方向延伸，难度显著提升。
+
+### 进阶实验一 设计类 CUDA 的 GPGPU 软件栈
+
+基础实验只验证了设备端（QEMU 里的 GPGPU 模型）的正确性，测题通过 QTest 直接写 MMIO 寄存器触发 kernel，并没有驱动与编程模型的概念。这道题要你补齐软件侧。
+
+挑战目标：为本方向实现的虚拟 GPGPU 设计一套**类 CUDA 风格**的最小软件栈，包含：
+
+- **内核驱动**：在 Linux 或 ArceOS/rCore 中注册 PCI 设备，管理 BAR、MSI-X、DMA 描述符，暴露字符设备或系统调用接口。
+- **用户态运行时库**（libgpgpu）：封装 `gpgpuMalloc` / `gpgpuMemcpy` / `gpgpuLaunchKernel` 等 API，内部通过 ioctl + mmap 与驱动通信。
+- **编程模型**：规定 kernel 函数签名（`__global__` 风格）、grid/block 维度、内置变量（threadIdx/blockIdx）；提供一个简易前端（可以是 clang 插件、或仅约定手写 RV32 汇编 + 头文件）。
+- **Demo**：至少跑通 vector add、矩阵乘、ReLU 三个 kernel，端到端验证 Host → Device → Host 数据链路。
+
+评估维度：软件栈的层次清晰度、API 设计的简洁性、以及对基础 17 道 QTest 所建模能力的覆盖程度。
+
+### 进阶实验二 把 Vortex simx 集成进 QEMU 并适配 AI 软件栈
+
+基础实验中 `hw/gpgpu/gpgpu_core.c` 的 SIMT 执行引擎是手写的简化 RV32I/RV32F 解释器，缺失真实 GPGPU 的 cache、scheduler、divergence handling。Vortex（[vortex.cc](https://vortex.cc/)）是一个学术界广泛使用的开源 RISC-V GPGPU 项目，其 `simx` 是一个用 C++ 写的 cycle-level 模拟器。
+
+挑战目标：把 Vortex 的 `simx` 作为 GPGPU 的后端直接嵌入到 QEMU 中，替换当前的简化 cmodel。
+
+建议路径：
+
+- 保留 `hw/gpgpu/gpgpu.c`（PCIe 前端、BAR、寄存器、DMA），只把 `gpgpu_core.c` 的执行后端替换为 `simx`。
+- 解决 C 与 C++ 的 ABI 桥接：用 extern "C" 封装 `simx` 的 `CoreSim`，在 kernel dispatch 时喂入程序计数器、参数、VRAM 视图。
+- 正确对接中断：kernel 执行完毕后通过 simx 回调触发 MSI-X。
+- 适配 AI 软件栈：把进阶实验一设计的 libgpgpu/驱动与 Vortex 的 POCL / OpenCL 运行时对齐，至少跑通一个 Vortex 原生示例（如 `sgemm`）。
+- 目标客户端 OS：ArceOS 或 rCore，验证内核驱动可以在两套真实 RISC-V OS 上工作。
+
+评估维度：集成的完整度、simx 相对手写 cmodel 的指令覆盖增量（cache/barrier/divergence 是否生效）、以及在真实 AI workload 上的正确性。
+
 [3]: https://classroom.github.com/a/hwWFrmo_
 [5]: gpu-datasheet.md

--- a/docs/exercise/2026/stage1/rust/rust-exper-manual.md
+++ b/docs/exercise/2026/stage1/rust/rust-exper-manual.md
@@ -152,5 +152,53 @@ make -f Makefile.camp test-rust
 
 每次 push 到 `main` 会触发 CI 评测，得分更新到[排行榜][4]。
 
+## 进阶实验
+
+!!! note "说明"
+
+    进阶实验为开放题目，不计入 100 分基础测评，但会作为训练营评优与推荐的重要参考。基础实验聚焦于总线/字符类外设（I2C、SPI），进阶方向则把 Rust 设备建模推进到块设备、PCIe、virtio 等 QEMU 中更复杂、更贴近生产环境的子系统。
+
+### 进阶实验一 Rust 实现 virtio-mmio 传输层
+
+挑战目标：用 Rust 重写 virtio-mmio 传输层的核心逻辑，并挂载到 G233 SoC（或 `riscv/virt` machine）上，对接 QEMU 现有的 virtio 设备后端（virtio-blk / virtio-net）。
+
+参考方向：
+
+- 阅读 `hw/virtio/virtio-mmio.c`，理清 MMIO 寄存器布局（`QueueSel`、`QueueNotify`、`InterruptStatus` 等）、virtqueue 的 kick / callback 生命周期。
+- 在 `rust/hw/virtio/` 下新建 crate，实现一个 `VirtioMmioTransport` 结构，暴露给 C 端的 VTable。
+- 最小验收：启动一个 Linux guest，能识别 Rust transport 下挂的 virtio-blk 设备并完成读写。
+
+### 进阶实验二 Rust 实现 virtio-blk 后端
+
+挑战目标：在进阶实验一的 transport 基础上，用 Rust 写一个完整的 virtio-blk 设备后端，复用 QEMU 的 `BlockBackend` 作为后端存储。
+
+关键点：
+
+- 处理 virtio-blk 的 feature negotiation（`VIRTIO_BLK_F_SEG_MAX`、`VIRTIO_BLK_F_FLUSH` 等）。
+- 正确使用 QEMU 的 AIO 线程池提交异步 I/O，用 Rust 的 `unsafe` + bindings 封装 `blk_aio_preadv` / `blk_aio_pwritev`。
+- 处理请求的描述符链解析、GPA → HVA 地址转换、状态字节写回。
+- 验收：挂一个 rootfs 镜像，让 Linux guest 能 `mount` 并读写。
+
+### 进阶实验三 Rust 实现 PCIe 设备建模
+
+挑战目标：参考 `hw/misc/edu.c`、`hw/misc/pci-testdev.c`，用 Rust 写一个挂在 PCIe 总线上的设备（可以是简易计算加速器、或最小的 NIC 原型）。
+
+要求至少覆盖以下 PCIe 特性：
+
+- PCI 配置空间（Vendor/Device ID、Class Code、BAR 规划）。
+- 至少一个 MMIO BAR 与一个可选的 I/O BAR，寄存器读写正确。
+- **MSI-X 中断**：实现 MSI-X Capability 和至少 4 个向量，设备内部事件能路由到 guest 中断。
+- **DMA**：设备能主动访问 guest 物理内存（用 `pci_dma_read` / `pci_dma_write` 对应的 Rust bindings）。
+
+验收：在 `riscv/virt` 或 `x86_64 pc` machine 上插入该设备，用一段小程序（可以是 QTest）验证 MMIO、MSI-X、DMA 三条链路。
+
+### 进阶实验四 把 GPGPU 方向的设备用 Rust 重写
+
+如果你同时完成了 GPU 方向，可以把 `hw/gpgpu/gpgpu.c`（PCIe 前端、BAR、DMA、MSI-X）或 `hw/gpgpu/gpgpu_core.c`（SIMT 解释器）移植到 Rust。
+
+建议先迁移前端的寄存器逻辑与 DMA 引擎，把 SIMT 执行后端留作 C，通过 Rust ↔ C FFI 互相调用；随后再尝试把 RV32I/RV32F 解释器也用 Rust 重写。
+
+评估维度：迁移范围、`unsafe` 使用是否克制、与原 C 实现的功能等价性（能否通过 GPGPU 方向的 17 道 QTest）。
+
 [3]: https://classroom.github.com/a/hwWFrmo_
 [4]: https://opencamp.cn/qemu/camp/2025/stage/3?tab=rank

--- a/docs/exercise/2026/stage1/soc/g233-exper-manual.md
+++ b/docs/exercise/2026/stage1/soc/g233-exper-manual.md
@@ -299,6 +299,75 @@ gdb -ex "target remote :1234" build/qemu-system-riscv64
 
 溢出原理：RXNE=1 时继续发送新数据 → 接收缓冲区满 → OVERRUN=1。
 
+## 进阶实验
+
+!!! note "说明"
+
+    进阶实验为开放题目，不计入 100 分基础测评，但会作为训练营评优与推荐的重要参考。建议在通过全部 10 道基础测题后再尝试，因为它们依赖完整的 G233 板级建模（CPU、内存、PLIC、CLINT、串口）。
+
+### 进阶实验一 为 G233 挂载 virtio-mmio 总线
+
+基础实验中 G233 只集成了 GPIO、PWM、WDT、SPI 等片内外设，没有块设备和网卡。virtio-mmio 是 QEMU 为嵌入式平台提供的轻量 virtio 传输层，非常适合挂到 G233 这种无 PCI 的 SoC 上。
+
+挑战目标：在 `hw/riscv/g233.c` 中预留一段 MMIO 地址空间（推荐 `0x1010_0000` 起），实例化 8 个 `virtio-mmio` transport slot，并把它们的中断线汇聚到 PLIC 上。
+
+参考方向：
+
+- 阅读 `hw/riscv/virt.c` 中 `create_virtio_regions` 的做法，把 slot 数、步长、中断号抽成 G233 machine 的常量。
+- 用 `sysbus_create_simple("virtio-mmio", ...)` 批量创建，注意每个 slot 间留出足够的步长（通常 0x200 / 0x1000）。
+- 更新 DTB（`create_fdt` 函数）中 `virtio_mmio@...` 节点，保证 guest 内核能发现设备。
+
+### 进阶实验二 接入 virtio-blk / virtio-net
+
+挑战目标：基于进阶实验一的 virtio-mmio 总线，让 G233 支持块设备与网卡：
+
+```bash
+qemu-system-riscv64 -M g233 \
+    -drive file=rootfs.ext4,format=raw,if=none,id=hd0 \
+    -device virtio-blk-device,drive=hd0 \
+    -netdev user,id=net0 \
+    -device virtio-net-device,netdev=net0
+```
+
+验收标准：
+
+- guest 内能看到 `/dev/vda` 和 `eth0`。
+- 对 `/dev/vda` 执行 `dd` 读写后重启数据保留。
+- `eth0` 通过 user-mode networking 可以 `ping 10.0.2.2`（QEMU 宿主）。
+
+### 进阶实验三 跑通 Linux 操作系统
+
+挑战目标：让 G233 能够作为标准 riscv64 Linux 的目标板，完整启动到 shell 提示符。
+
+建议步骤：
+
+1. **构建内核**：从 kernel.org 获取稳定版 Linux（推荐 ≥ 6.6），开启 `CONFIG_SOC_VIRT`、virtio-blk/net、串口、devtmpfs，以及 G233 所用中断控制器的支持（PLIC + CLINT）。
+2. **构建根文件系统**：用 buildroot 或 BusyBox 定制最小镜像，默认 init 进入 `/bin/sh`。
+3. **Bootloader**：先用 `-bios default`（OpenSBI）直接加载 kernel Image；进阶可接入 U-Boot 做二级引导。
+4. **DTB 完备化**：补全 `create_fdt` 中的 CPU、memory、clock、serial、virtio-mmio 节点，并把 `bootargs` 默认设为 `root=/dev/vda rw console=ttyS0 earlycon`。
+5. **最终启动命令示例**：
+
+    ```bash
+    qemu-system-riscv64 -M g233 -nographic \
+        -bios default -kernel Image \
+        -append "root=/dev/vda rw console=ttyS0 earlycon" \
+        -drive file=rootfs.ext4,format=raw,if=none,id=hd0 \
+        -device virtio-blk-device,drive=hd0
+    ```
+
+验收标准：从加电到进入 shell、能执行 `uname -a`、`ls /dev`、`cat /proc/cpuinfo` 看到正确的 hart 数量；启动日志中可以看到 OpenSBI → Linux 内核自解压 → 用户空间 init 的完整链路。
+
+### 进阶实验四 扩展 virtio 设备族
+
+在前三个进阶实验的基础上，进一步扩展 G233 支持的 virtio 设备：
+
+- `virtio-rng`：为 Linux 内核提供熵源，缓解 `random: crng init done` 长时间阻塞。
+- `virtio-console`：作为第二个串口/管理通道。
+- `virtio-9p`：通过 9P 协议把宿主机目录挂载到 guest，便于调试时共享文件。
+- `virtio-gpu`（更高难度）：接入 G233 显示子系统，做最小的 framebuffer 输出。
+
+产出一份说明文档，介绍各 virtio 设备的启动参数、使用方式、以及在 G233 上的性能/兼容性表现。
+
 [1]: https://qemu.readthedocs.io/en/v10.0.3/devel/build-environment.html
 [2]: https://github.com/riscv-collab/riscv-gnu-toolchain/releases/
 [3]: https://classroom.github.com/a/hwWFrmo_


### PR DESCRIPTION
## Summary

为专业阶段（stage1）四个方向的实验手册新增「进阶实验」开放题目，作为训练营评优与推荐的参考（不计入 100 分基础测评）：

- **CPU 方向** (`cpu-exper-manual.md`)
    - 进阶一：Helper → 内联 TCG IR 重写（`vadd` / `vrelu` / `vscale`）
    - 进阶二：基于 TCG Plugin（`hotblocks` / `insn` / `cache`）的翻译性能分析
    - 进阶三：MTTCG 多线程下的正确性与加速比
    - 进阶四：为 Xg233ai 指令加装性能计数器，产出指令使用热度表

- **SoC 方向** (`g233-exper-manual.md`)
    - 进阶一：为 G233 挂载 virtio-mmio 总线（参考 `hw/riscv/virt.c`）
    - 进阶二：接入 virtio-blk / virtio-net，guest 内看到 `/dev/vda`、`eth0`
    - 进阶三：跑通 riscv64 Linux（OpenSBI → Kernel → rootfs → shell），给出完整启动命令
    - 进阶四：扩展 virtio-rng / virtio-console / virtio-9p / virtio-gpu 设备族

- **GPU 方向** (`gpu-exper-manual.md`)
    - 将原本只记录在 `gpu/index.md` 的两道开放题目搬进实验手册，并补充建议路径
    - 进阶一：设计类 CUDA 风格的最小 GPGPU 软件栈（驱动 + 运行时 + 编程模型 + Demo）
    - 进阶二：把 Vortex simx 作为 cmodel 后端集成进 QEMU，并在 ArceOS/rCore 上适配 AI 软件栈

- **Rust 方向** (`rust-exper-manual.md`)
    - 进阶一：Rust 实现 virtio-mmio 传输层
    - 进阶二：Rust 实现 virtio-blk 后端，对接 `BlockBackend`
    - 进阶三：Rust 实现 PCIe 设备建模（BAR + MSI-X + DMA）
    - 进阶四：把 GPGPU 方向的 `hw/gpgpu/*` 逐步用 Rust 重写

## Test plan

- [x] `autocorrect --lint` 对四个手册通过（No issues found）
- [x] `markdownlint-cli2` 对本次新增内容通过（剩余 1 处 pre-existing MD012 不在本次变更范围）
- [ ] `zensical serve` 本地预览，确认四个手册的「进阶实验」章节正常渲染
- [ ] 人工 Review 文案口径与基础实验的一致性