### PR TITLE
docs/tutorial/2026/ch1: fix qom UML diagram rendering and quiz link typo

### DIFF
--- a/docs/tutorial/2026/ch1/qemu-qom.md
+++ b/docs/tutorial/2026/ch1/qemu-qom.md
@@ -391,41 +391,47 @@ struct PCIDeviceClass {
 
 首先用 UML 类图展示它们的继承层次与各自的字段：
 
-```mermaid
-classDiagram
-    class ObjectClass {
-        +Type type
-        +const char *class_cast_cache[]
-        +ObjectUnparentFunc unparent
-        +GHashTable *properties
-    }
+```
+          +--------------------------------------+
+          |             ObjectClass              |
+          |--------------------------------------|
+          | + Type                    type       |
+          | + const char *class_cast_cache[]     |
+          | + ObjectUnparentFunc      unparent   |
+          | + GHashTable             *properties |
+          +--------------------------------------+
+                            ^
+                            | 继承（parent_class 作为第一个成员域）
+                            |
+          +--------------------------------------+
+          |             DeviceClass              |
+          |--------------------------------------|
+          | + ObjectClass             parent_class
+          |--------------------------------------|
+          | + DeviceRealize           realize    |
+          | + DeviceUnrealize         unrealize  |
+          | + const Property         *props      |
+          | + bool                    hotpluggable
+          +--------------------------------------+
+                            ^
+                            | 继承（parent_class 作为第一个成员域）
+                            |
+          +--------------------------------------+
+          |            PCIDeviceClass            |
+          |--------------------------------------|
+          | + DeviceClass             parent_class
+          |--------------------------------------|
+          | + PCIDeviceRealize        realize    |
+          | + uint16_t                vendor_id  |
+          | + uint16_t                device_id  |
+          | + uint8_t                 revision   |
+          | + uint16_t                class_id   |
+          | + const char             *romfile    |
+          +--------------------------------------+
 
-    class DeviceClass {
-        +ObjectClass parent_class
-        ---
-        +DeviceRealize realize
-        +DeviceUnrealize unrealize
-        +const Property *props
-        +bool hotpluggable
-    }
-
-    class PCIDeviceClass {
-        +DeviceClass parent_class
-        ---
-        +PCIDeviceRealize realize
-        +uint16_t vendor_id
-        +uint16_t device_id
-        +uint8_t revision
-        +uint16_t class_id
-        +const char *romfile
-    }
-
-    ObjectClass <|-- DeviceClass : parent_class (first field)
-    DeviceClass <|-- PCIDeviceClass : parent_class (first field)
-
-    note for ObjectClass "offset 0x0: all types share this header"
-    note for DeviceClass "offset 0x0: starts with ObjectClass\nthen device-specific fields"
-    note for PCIDeviceClass "offset 0x0: starts with DeviceClass\nthen PCI-specific fields"
+  说明：每一层的 parent_class 都位于子类结构体的 offset 0x0，
+        因此 (ObjectClass *) / (DeviceClass *) / (PCIDeviceClass *)
+        三个指针共享同一起始地址。
 ```
 
 C 语言通过将父类结构体作为子类的**第一个成员域**（offset 0），实现了类似 C++ 的继承内存布局——子类指针可以直接强制转换为父类指针，因为它们在内存起始位置共享相同的布局。下面用内存布局图来直观展示这种包含关系：
@@ -785,4 +791,4 @@ void qdev_init_gpio_out_named(DeviceState *dev, qemu_irq *pins,
 
 !!! question "随堂测验"
 
-    [>> 【点击进入随堂测验】2-3 分钟小测，快速巩固 ☄](hhttps://ima.qq.com/quiz?quizId=1J6CHlpvIscf7N8tJ9n2EvtVJC6EcvYNvRTOsQfZN0R)
+    [>> 【点击进入随堂测验】2-3 分钟小测，快速巩固 ☄](https://ima.qq.com/quiz?quizId=1J6CHlpvIscf7N8tJ9n2EvtVJC6EcvYNvRTOsQfZN0R)


### PR DESCRIPTION
## 关联章节/文件
- 文档路径：`docs/tutorial/2026/ch1/qemu-qom.md`

## 修改类型
- [x] 错别字/语句修正
- [x] 格式调整

## 修改描述
修复当前线上 <https://qemu.gevico.online/tutorial/2026/ch1/qemu-qom/> 页面的两处渲染问题：

- **UML 类图不渲染**：原文使用 ` ```mermaid classDiagram ` 代码块，但项目的 `mkdocs.yml` 仅在 `pymdownx.superfences` 里注册了 `mermaid` 自定义 fence，并未通过 `extra_javascript` 引入 `mermaid.js`（全项目也仅此一处 mermaid），因此线上只显示原始代码块源码。本次将其改写为与本文件其它示意图一致的 ASCII UML 类图，保留 `ObjectClass → DeviceClass → PCIDeviceClass` 三层继承和字段信息，并保留 "parent_class 位于 offset 0x0" 的关键说明。
- **随堂测验链接失效**：文末链接协议头误写为 `hhttps://`（多了一个 `h`），导致点击跳转到 404。本次修正为 `https://`。

## 本地验证
- [ ] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [ ] 已执行 `zensical serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观

> 备注：本 PR 改动仅为纯 Markdown 文本（替换 mermaid 代码块为 ASCII、以及修正一个字符），合入前请作者/维护者在本地补跑上述两项检查。