### PR TITLE
docs/tutorial/2026/ch0: fix compile_commands.json generation description

### DIFF
--- a/docs/tutorial/2026/ch0/qemu-dev-env.md
+++ b/docs/tutorial/2026/ch0/qemu-dev-env.md
@@ -155,15 +155,11 @@ Copyright (c) 2003-2025 Fabrice Bellard and the QEMU Project developers
 
 ## 开发工具配置
 
-### 生成 compile_commands.json
+### compile_commands.json
 
-为 IDE 提供代码补全和跳转支持：
+Meson 在 configure 阶段会自动在 `build/` 目录下生成 `compile_commands.json`，无需手动执行额外命令。编译完成后即可直接使用，为 IDE 提供代码补全和跳转支持。
 
-```bash
-ninja -C build compile_commands.json
-```
-
-生成的 `build/compile_commands.json` 可被 VSCode（C/C++ 插件或 clangd）、Vim（coc-clangd）等编辑器识别。
+`build/compile_commands.json` 可被 VSCode（C/C++ 插件或 clangd）、Vim（coc-clangd）等编辑器识别。
 
 ### VSCode 配置
 

--- a/docs/tutorial/2026/ch1/qemu-startup-param.md
+++ b/docs/tutorial/2026/ch1/qemu-startup-param.md
@@ -12,7 +12,6 @@ QEMU 是一款功能强大的开源虚拟化和仿真软件，支持多种处理
 
 本章节将聚焦 QEMU 常用启动参数，以启动 OpenEuler RISC-V 系统为实例，重点讲解主板选型、CPU 配置、设备添加等核心操作，进而介绍如何精准查找适配自身需求的 QEMU 启动参数，抛砖引玉助力读者掌握相关应用方法。
 
-
 !!! tip "概览"
 
     - 启动参数分类与常用选项速查
@@ -46,13 +45,11 @@ QEMU 是一款功能强大的开源虚拟化和仿真软件，支持多种处理
 |  `-append`            | `-append "console=ttyS0"` | 传递给内核的命令行参数（direct Linux boot 场景，通常与 `-kernel` 配合使用） |
 |  `-dtb`               | `-dtb kernel.dtb`         | 传递给内核的 DTB（Device Tree Blob，设备树二进制文件，用于描述硬件拓扑，供内核发现和配置设备）镜像文件 |
 
-
 **存储设备参数**：
 
 |       parameter       |          example          |     Description    |
 |          ---          |           ----            |        ----        |
 |  `-drive`             | `-drive file=image.qcow2,format=qcow2,if=virtio` | 添加块设备（硬盘、光盘等）|
-
 
 **网络参数**：
 
@@ -146,6 +143,75 @@ unxz -k openEuler-24.03-LTS-SP2-riscv64.qcow2.xz
 chmod +x start_vm.sh
 ./start_vm.sh
 ```
+
+启动后等待内核加载完成，出现 `localhost login:` 提示即可登录。
+
+### 登录虚拟机
+
+openEuler RISC-V 镜像的默认登录信息：
+
+| 项目 | 值 |
+|------|------|
+| 用户名 | `root` |
+| 密码 | `openEuler12#$` |
+
+#### 串口直接登录
+
+在当前终端输入用户名和密码即可：
+
+```text
+localhost login: root
+Password:
+
+Welcome to 6.6.0-98.0.0.103.oe2403sp2.riscv64
+
+System information as of time: Fri Jun 13 05:59:56 PM UTC 2025
+
+System load:    2.87
+Memory used:    1.5%
+Swap used:      0.0%
+Usage On:       4%
+IP address:     10.0.2.15
+Users online:   1
+
+[root@localhost ~]#
+```
+
+#### SSH 远程登录
+
+如果启动参数中配置了端口转发（如 `hostfwd=::12055-:22`），可以通过 SSH 登录：
+
+```bash
+ssh -p 12055 root@localhost
+```
+
+首次连接会提示确认主机指纹，输入 `yes` 后输入密码即可：
+
+```text
+The authenticity of host '[localhost]:12055 ([127.0.0.1]:12055)' can't be established.
+ED25519 key fingerprint is SHA256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+```
+
+!!! note
+
+    此处指纹值因镜像和密钥不同而异，首次连接时输入 `yes` 确认即可。
+
+```text
+root@localhost's password:
+
+Welcome to 6.6.0-98.0.0.103.oe2403sp2.riscv64
+
+[root@localhost ~]#
+```
+
+!!! tip "登录后建议"
+
+    首次登录后建议立即修改默认密码：
+
+    ```bash
+    passwd root
+    ```
 
 ## 查阅 QEMU 启动参数
 


### PR DESCRIPTION
## 关联章节/文件
<!-- 请填写您修改的文档路径或代码文件路径，例如： -->
- 文档路径：`docs/tutorial/2026/ch0/qemu-dev-env.md` & `docs/tutorial/2026/ch1`

## 修改类型
<!-- 请选择一项或多项，并用 [x] 标记 -->
- [x] 内容补充
- [x] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述
<!-- 请简要描述您本次修改的主要内容和原因 -->
- 修正 compile_commands.json 生成方式说明：Meson 在 configure 阶段自动生成，删除无效的 ninja -C build compile_commands.json 命令
- 补充 openEuler VM login instructions


## 本地验证
<!-- 请确保您已在本地完成以下检查 -->
- [x] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [x] 已执行 `zensical serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观

## 附加说明 (可选)
<!-- 如有其他需要说明的事项，请在此填写 -->