### PR TITLE
docs: update G233 GPIO notes and status

### DIFF
--- a/docs/exercise/2026/stage1/soc/g233-datasheet.md
+++ b/docs/exercise/2026/stage1/soc/g233-datasheet.md
@@ -324,7 +324,8 @@ GPIO 基地址：`0x1001_2000`。
 2. 配置 `GPIO_POL[N]` 选择触发极性（`0` 低/下降、`1` 高/上升）。
 3. 置位 `GPIO_IE[N]` 使能中断。
 4. 中断发生后，读 `GPIO_IS` 确认触发引脚，向对应位写 `1` 清除 GPIO 侧中断标志。
-5. 注意：清除 `GPIO_IS` 不会自动清除 PLIC 侧的 pending 位。软件还需在 PLIC 侧执行 claim/complete 流程（见 §5.3）以清除对应 IRQ 的 pending。
+5. 注意：当 `GPIO_TRIG[N]` 选择电平触发时，向 `GPIO_OUT[N]` 写入 `~GPIO_POL[N]` 后，GPIO 应当清空对应的 `GPIO_IS[N]` 状态位。
+6. 注意：清除 `GPIO_IS` 不会自动清除 PLIC 侧的 pending 位。软件还需在 PLIC 侧执行 claim/complete 流程（见 §5.3）以清除对应 IRQ 的 pending。
 
 ## 8. PWM 控制器
 

--- a/docs/exercise/2026/stage1/soc/g233-exper-manual.md
+++ b/docs/exercise/2026/stage1/soc/g233-exper-manual.md
@@ -143,7 +143,7 @@ gdb -ex "target remote :1234" build/qemu-system-riscv64
 | --- | --- |
 | 源码路径 | `tests/gevico/qtest/test-board-g233.c` |
 | 功能描述 | 验证 G233 Board 基本工作，包括 CPU 启动、内存映射、MMIO 总线连通性 |
-| 基础代码 | `hw/riscv/g233.c`（需补全） |
+| 基础代码 | `hw/riscv/g233.c`（已完成） |
 | 详细规格 | [G233 SoC 硬件手册][5] §3-§5 |
 
 ### 实验二 test-gpio-basic


### PR DESCRIPTION
Document how level-triggered GPIO interrupts clear GPIO_IS when GPIO_OUT is driven to the inactive polarity.

Mark the G233 board base implementation as completed in the experiment manual.

## 关联章节/文件
<!-- 请填写您修改的文档路径或代码文件路径，例如： -->
- 文档路径：`docs/exercise/2026/stage1/soc/g233-datasheet.md`
- 文档路径：`docs/exercise/2026/stage1/soc/g233-exper-manual.md`

## 修改类型
<!-- 请选择一项或多项，并用 [x] 标记 -->
- [x] 内容补充
- [ ] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述
对于gpio实验文档与源码实现


## 本地验证
<!-- 请确保您已在本地完成以下检查 -->
- [x] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [x] 已执行 `zensical serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观

## 附加说明 (可选)
<!-- 如有其他需要说明的事项，请在此填写 -->