### PR TITLE
修复2026 基础阶段对memory region树状结构的不当描述并添加关于前后两种内存视角的联系

### DIFF
--- a/docs/tutorial/2026/ch1/qemu-mr.md
+++ b/docs/tutorial/2026/ch1/qemu-mr.md
@@ -382,7 +382,10 @@ memory_region_update_container_subregions() 的过程很简单，最终执行的
           ...                                            ...
 ```
 
-是不是很像一个树形结构？其实这就是红黑树。
+
+这样一种结构在底层形成了一棵庞大的多叉树。其中，subregions 链表在 `memory_region_initfn` 函数中完成初始化，负责在树状拓扑中串联同级兄弟节点并管理下级子节点。然而在虚拟机实际运行阶段，为了满足 CPU 的极速访存需求，这棵多叉树会通过 QEMU 的 `generate_memory_topology` 等一系列算法，根据节点的绝对地址范围和优先级进行动态的计算与裁剪，最终被拍扁成一个一维的平坦视图（FlatView 数组）。这种降维处理使得复杂的树形遍历转变为高效的 $O(\log N)$ 二分查找（配合 Dispatch 缓存可达近似 $O(1)$ 的极速内存路由）。这个平坦的一维数组，正是我们之前提到的[地址空间布局](#memory-region-面向地址空间抽象)。
+
+ 总结来说:  一维的地址空间布局（FlatView）是最终提交给 QEMU 执行引擎的高性能物理内存结构；而多叉的树状拓扑（MemoryRegion Tree）则是提供给开发者在编写外设代码时，用于解耦和理解设备间相对挂载空间的逻辑模型。
 
 address-space 内有一个 root 字段，指向 memory-region 的根节点，这样就实现了一个 address-space 对应一个 memory-region 树，如下：
 


### PR DESCRIPTION
## 关联章节/文件
<!-- 请填写您修改的文档路径或代码文件路径，例如： -->
- 文档路径：`docs/1-install/2-partition.md`

## 修改类型
<!-- 请选择一项或多项，并用 [x] 标记 -->
- [x] 内容补充
- [ ] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述
<!-- 请简要描述您本次修改的主要内容和原因 -->
- 在原`qemu-mr.md`文件中将`MemoryRegion`的树状结构描述为红黑树不大准确，应该为多叉树 
- 原`qemu-mr.md`文件先后介绍了最后运行过程中的内存视图和实际代码中构建的内存树，但是没有指明这种视角的切换和`qemu`采用这种内存视图的原因

## 本地验证
<!-- 请确保您已在本地完成以下检查 -->
- [x] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [x] 已执行 `zensical serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观

## 附加说明 (可选)
<!-- 如有其他需要说明的事项，请在此填写 -->