### PR TITLE
docs/signup: add GitHub Issue signup flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/signup.yml
+++ b/.github/ISSUE_TEMPLATE/signup.yml
@@ -1,0 +1,28 @@
+name: QEMU 训练营报名
+description: 提交 QEMU 训练营报名信息
+title: "[报名] "
+labels:
+  - signup
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢报名 QEMU 训练营。当前报名只需要填写 GitHub 用户名。
+        请不要在报名表中填写手机号、邮箱、身份证号等隐私信息。
+
+  - type: input
+    id: github_username
+    attributes:
+      label: GitHub 用户名
+      description: 请填写后续用于接收实验仓库权限的 GitHub 用户名。
+      placeholder: 例如：bbbbbq
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: 确认事项
+      options:
+        - label: 我确认上述 GitHub 用户名将作为后续实验仓库授权账号。
+          required: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: Documentation
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types:
+      - signup-board-updated
   push:
     branches:
       - master
@@ -13,7 +16,7 @@ permissions:
   contents: read
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,14 +11,17 @@ on:
       - main
 permissions:
   contents: read
+concurrency:
+  group: pages
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.x
+          python-version: "3.13"
       - name: Build documentation
         run: |
           set -o pipefail
@@ -31,26 +34,18 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     needs: build
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/configure-pages@v5
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.x
+          python-version: "3.13"
       - run: make build
-      - uses: actions/upload-pages-artifact@v4
+      - uses: peaceiris/actions-gh-pages@v4
         with:
-          name: github-pages-${{ github.run_attempt }}
-          path: site
-      - id: deployment
-        uses: actions/deploy-pages@v4
-        with:
-          artifact_name: github-pages-${{ github.run_attempt }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./site
+          force_orphan: true

--- a/.github/workflows/signup.yml
+++ b/.github/workflows/signup.yml
@@ -38,46 +38,20 @@ jobs:
             const defaultBranch = context.payload.repository?.default_branch ?? "main";
             const signupConfigPath = "docs/data/signup-config.json";
             const signupPagePath = "docs/signup.md";
-            const defaultClosedMessage = "QEMU 训练营报名暂未开放，请关注后续通知。";
 
             const signupLabel = {
               name: "signup",
               color: "5319e7",
               description: "QEMU camp signup issue.",
             };
-            const statusLabels = {
-              processing: {
-                name: "signup/processing",
-                color: "1d76db",
-                description: "Signup automation is processing this issue.",
-              },
-              success: {
-                name: "signup/success",
-                color: "0e8a16",
-                description: "Signup validation completed successfully.",
-              },
-              invalid: {
-                name: "signup/invalid",
-                color: "d73a4a",
-                description: "Signup issue failed validation.",
-              },
-              duplicate: {
-                name: "signup/duplicate",
-                color: "fbca04",
-                description: "Signup issue duplicates an existing signup.",
-              },
-              failed: {
-                name: "signup/failed",
-                color: "b60205",
-                description: "Signup automation failed unexpectedly.",
-              },
-              closed: {
-                name: "signup/closed",
-                color: "6a737d",
-                description: "Signup issue was submitted while signup is closed.",
-              },
-            };
-            const allStatusLabels = Object.values(statusLabels).map((label) => label.name);
+            const oldStatusLabelNames = [
+              "signup/processing",
+              "signup/success",
+              "signup/invalid",
+              "signup/duplicate",
+              "signup/failed",
+              "signup/closed",
+            ];
 
             const signupTitlePrefix = String.fromCharCode(91, 25253, 21517, 93);
             const usernamePattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
@@ -117,8 +91,8 @@ jobs:
               }
             }
 
-            async function removeStatusLabels() {
-              for (const label of allStatusLabels) {
+            async function removeOldStatusLabels() {
+              for (const label of oldStatusLabelNames) {
                 try {
                   await github.rest.issues.removeLabel({
                     owner,
@@ -132,42 +106,6 @@ jobs:
                   }
                 }
               }
-            }
-
-            async function setStatus(label) {
-              await removeStatusLabels();
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                labels: [label],
-              });
-            }
-
-            async function commentOnce(marker, body) {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: issueNumber,
-                per_page: 100,
-              });
-              const existing = comments.find((comment) => comment.body?.includes(marker));
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existing.id,
-                  body,
-                });
-                return;
-              }
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body,
-              });
             }
 
             async function readTextFile(path) {
@@ -213,12 +151,6 @@ jobs:
                 }
                 throw error;
               }
-            }
-
-            function signupClosedMessage(config) {
-              return typeof config.closed_message === "string" && config.closed_message.trim()
-                ? config.closed_message.trim()
-                : defaultClosedMessage;
             }
 
             async function writeTextFile(path, sha, content, message) {
@@ -311,16 +243,7 @@ jobs:
             async function updateSignupBoard({ username, issueUrl, issueNumber }) {
               const { sha, content } = await readTextFile(signupPagePath);
               const records = parseSignupBoardRecords(content);
-              const existingRecord = records.find((record) => record.github_username.toLowerCase() === username.toLowerCase());
               const now = new Date().toISOString();
-
-              if (existingRecord) {
-                if (existingRecord.issue_number === issueNumber) {
-                  return { path: signupPagePath, updated: false };
-                }
-
-                throw new Error(`GitHub user ${username} already exists in signup board.`);
-              }
 
               records.push({
                 github_username: username,
@@ -360,32 +283,6 @@ jobs:
                   issue_number: issueNumber,
                 },
               });
-            }
-
-            function formatRepositoryList(repositories) {
-              if (!repositories.length) {
-                return [
-                  "- 暂无。实验仓库创建、fork 和授权步骤接入后会更新报名记录和本评论。",
-                ];
-              }
-
-              return repositories.map((repository) => {
-                const permissionText = repository.permission ? `，权限：${repository.permission}` : "";
-                return `- [${repository.name}](${repository.url})${permissionText}`;
-              });
-            }
-
-            function formatInviteNotice(repositories) {
-              if (!repositories.length) {
-                return "当前没有需要接受的仓库邀请。后续私有实验仓库创建后，请在 GitHub 通知中接受邀请。";
-              }
-
-              const hasInvitation = repositories.some((repository) => repository.invitation_required);
-              if (hasInvitation) {
-                return "如果 GitHub 发送了仓库邀请，请先在 GitHub 通知中接受邀请，然后再访问实验仓库。";
-              }
-
-              return "仓库权限已经配置完成，可以直接访问上方实验仓库链接。";
             }
 
             function cleanFieldValue(rawValue) {
@@ -447,12 +344,11 @@ jobs:
               return issues.find((candidateIssue) => (
                 candidateIssue.number !== issueNumber
                 && !candidateIssue.pull_request
-                && !candidateIssue.labels.some((label) => ["signup/invalid", "signup/duplicate"].includes(label.name))
                 && issueMentionsUsername(candidateIssue, username)
               ));
             }
 
-            await Promise.all([signupLabel, ...Object.values(statusLabels)].map(ensureLabel));
+            await ensureLabel(signupLabel);
             if (!hasSignupLabel) {
               await github.rest.issues.addLabels({
                 owner,
@@ -461,27 +357,15 @@ jobs:
                 labels: [signupLabel.name],
               });
             }
+            await removeOldStatusLabels();
 
             const signupConfig = await readJsonFile(signupConfigPath);
             if (signupConfig.enabled === false) {
-              const closedMessage = signupClosedMessage(signupConfig);
-              await setStatus(statusLabels.closed.name);
-              await commentOnce(
-                "<!-- signup-closed -->",
-                [
-                  "<!-- signup-closed -->",
-                  closedMessage,
-                  "",
-                  "报名功能当前由管理员关闭，本 Issue 暂不会进入报名处理流程。",
-                ].join("\n")
-              );
+              core.info(`Skip issue #${issueNumber}: signup is closed.`);
               return;
             }
 
-            await setStatus(statusLabels.processing.name);
-
             let username = "";
-            const createdRepositories = [];
 
             try {
               username = normalizeUsername(
@@ -490,18 +374,7 @@ jobs:
               const issueAuthor = issue.user.login;
 
               if (!usernamePattern.test(username)) {
-                await setStatus(statusLabels.invalid.name);
-                await commentOnce(
-                  "<!-- signup-invalid-username -->",
-                  [
-                    "<!-- signup-invalid-username -->",
-                    "报名校验失败：GitHub 用户名格式不正确。",
-                    "",
-                    `当前解析到的用户名：\`${username || "(空)"}\``,
-                    "",
-                    "请修改 Issue 中的 GitHub 用户名后重新提交。",
-                  ].join("\n")
-                );
+                core.info(`Skip issue #${issueNumber}: invalid GitHub username "${username}".`);
                 return;
               }
 
@@ -514,50 +387,18 @@ jobs:
                   throw error;
                 }
 
-                await setStatus(statusLabels.invalid.name);
-                await commentOnce(
-                  "<!-- signup-invalid-user-not-found -->",
-                  [
-                    "<!-- signup-invalid-user-not-found -->",
-                    "报名校验失败：没有找到这个 GitHub 用户。",
-                    "",
-                    `请确认用户名 \`${username}\` 是否拼写正确。`,
-                  ].join("\n")
-                );
+                core.info(`Skip issue #${issueNumber}: GitHub user "${username}" was not found.`);
                 return;
               }
 
               if (username.toLowerCase() !== issueAuthor.toLowerCase()) {
-                await setStatus(statusLabels.invalid.name);
-                await commentOnce(
-                  "<!-- signup-invalid-author-mismatch -->",
-                  [
-                    "<!-- signup-invalid-author-mismatch -->",
-                    "报名校验失败：Issue 创建者和填写的 GitHub 用户名不一致。",
-                    "",
-                    `Issue 创建者：\`${issueAuthor}\``,
-                    `填写的用户名：\`${username}\``,
-                    "",
-                    "请使用需要参加训练营的 GitHub 账号创建报名 Issue。",
-                  ].join("\n")
-                );
+                core.info(`Skip issue #${issueNumber}: issue author "${issueAuthor}" does not match "${username}".`);
                 return;
               }
 
               const duplicateIssue = await findDuplicateSignup(username);
               if (duplicateIssue) {
-                await setStatus(statusLabels.duplicate.name);
-                await commentOnce(
-                  "<!-- signup-duplicate -->",
-                  [
-                    "<!-- signup-duplicate -->",
-                    "检测到重复报名。",
-                    "",
-                    `GitHub 用户 \`${username}\` 已经提交过报名：#${duplicateIssue.number}`,
-                    "",
-                    "请不要重复提交报名 Issue。",
-                  ].join("\n")
-                );
+                core.info(`Skip issue #${issueNumber}: duplicate signup for "${username}" in #${duplicateIssue.number}.`);
                 return;
               }
 
@@ -573,33 +414,7 @@ jobs:
                   issueNumber: issue.number,
                 });
               }
-
-              await setStatus(statusLabels.success.name);
-              await commentOnce(
-                "<!-- signup-success -->",
-                [
-                  "<!-- signup-success -->",
-                  "报名成功。",
-                  "",
-                  `GitHub 用户：\`${username}\``,
-                  `报名看板：\`${boardUpdate.path}\``,
-                  "",
-                  "已创建或配置的实验仓库：",
-                  ...formatRepositoryList(createdRepositories),
-                  "",
-                  formatInviteNotice(createdRepositories),
-                ].join("\n")
-              );
+              core.info(`Signup succeeded for "${username}". Board: ${boardUpdate.path}.`);
             } catch (error) {
-              await setStatus(statusLabels.failed.name);
-              await commentOnce(
-                "<!-- signup-failed -->",
-                [
-                  "<!-- signup-failed -->",
-                  "报名自动化处理失败，需要维护者检查 GitHub Actions 日志。",
-                  "",
-                  `错误信息：\`${error.message}\``,
-                ].join("\n")
-              );
               throw error;
             }

--- a/.github/workflows/signup.yml
+++ b/.github/workflows/signup.yml
@@ -38,7 +38,9 @@ jobs:
               ? Number(core.getInput("issue_number"))
               : context.payload.issue.number;
             const defaultBranch = context.payload.repository?.default_branch ?? "main";
-            const signupYear = process.env.SIGNUP_YEAR;
+            let signupYear = process.env.SIGNUP_YEAR;
+            const signupConfigPath = "docs/data/signup-config.json";
+            const defaultClosedMessage = "QEMU 训练营报名暂未开放，请关注后续通知。";
 
             const signupLabel = {
               name: "signup",
@@ -70,6 +72,11 @@ jobs:
                 name: "signup/failed",
                 color: "b60205",
                 description: "Signup automation failed unexpectedly.",
+              },
+              closed: {
+                name: "signup/closed",
+                color: "6a737d",
+                description: "Signup issue was submitted while signup is closed.",
               },
             };
             const allStatusLabels = Object.values(statusLabels).map((label) => label.name);
@@ -180,6 +187,39 @@ jobs:
                 }
                 throw error;
               }
+            }
+
+            async function readJsonFile(path) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path,
+                  ref: defaultBranch,
+                });
+
+                if (Array.isArray(data)) {
+                  return {};
+                }
+
+                try {
+                  return JSON.parse(Buffer.from(data.content, data.encoding ?? "base64").toString("utf8"));
+                } catch (error) {
+                  core.warning(`Failed to parse ${path}: ${error.message}`);
+                  return {};
+                }
+              } catch (error) {
+                if (error.status === 404) {
+                  return {};
+                }
+                throw error;
+              }
+            }
+
+            function signupClosedMessage(config) {
+              return typeof config.closed_message === "string" && config.closed_message.trim()
+                ? config.closed_message.trim()
+                : defaultClosedMessage;
             }
 
             async function writeJsonFile(path, data, message) {
@@ -326,6 +366,24 @@ jobs:
                 labels: [signupLabel.name],
               });
             }
+
+            const signupConfig = await readJsonFile(signupConfigPath);
+            signupYear = String(signupConfig.year || signupYear);
+            if (signupConfig.enabled === false) {
+              const closedMessage = signupClosedMessage(signupConfig);
+              await setStatus(statusLabels.closed.name);
+              await commentOnce(
+                "<!-- signup-closed -->",
+                [
+                  "<!-- signup-closed -->",
+                  closedMessage,
+                  "",
+                  "报名功能当前由管理员关闭，本 Issue 暂不会进入报名处理流程。",
+                ].join("\n")
+              );
+              return;
+            }
+
             await setStatus(statusLabels.processing.name);
 
             let username = "";

--- a/.github/workflows/signup.yml
+++ b/.github/workflows/signup.yml
@@ -1,0 +1,459 @@
+name: Signup
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to reprocess
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: signup-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.issue.title, '[报名]')
+    runs-on: ubuntu-latest
+    env:
+      SIGNUP_YEAR: "2026"
+    steps:
+      - name: Validate signup issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.eventName === "workflow_dispatch"
+              ? Number(core.getInput("issue_number"))
+              : context.payload.issue.number;
+            const defaultBranch = context.payload.repository?.default_branch ?? "main";
+            const signupYear = process.env.SIGNUP_YEAR;
+
+            const signupLabel = {
+              name: "signup",
+              color: "5319e7",
+              description: "QEMU camp signup issue.",
+            };
+            const statusLabels = {
+              processing: {
+                name: "signup/processing",
+                color: "1d76db",
+                description: "Signup automation is processing this issue.",
+              },
+              success: {
+                name: "signup/success",
+                color: "0e8a16",
+                description: "Signup validation completed successfully.",
+              },
+              invalid: {
+                name: "signup/invalid",
+                color: "d73a4a",
+                description: "Signup issue failed validation.",
+              },
+              duplicate: {
+                name: "signup/duplicate",
+                color: "fbca04",
+                description: "Signup issue duplicates an existing signup.",
+              },
+              failed: {
+                name: "signup/failed",
+                color: "b60205",
+                description: "Signup automation failed unexpectedly.",
+              },
+            };
+            const allStatusLabels = Object.values(statusLabels).map((label) => label.name);
+
+            const signupTitlePrefix = String.fromCharCode(91, 25253, 21517, 93);
+            const usernamePattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            const hasSignupLabel = issue.labels.some((label) => label.name === "signup");
+            const hasSignupTitle = issue.title.startsWith(signupTitlePrefix);
+            if (!hasSignupTitle) {
+              core.info(`Skip issue #${issueNumber}: not a signup issue.`);
+              return;
+            }
+
+            async function ensureLabel(label) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              }
+            }
+
+            async function removeStatusLabels() {
+              for (const label of allStatusLabels) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    name: label,
+                  });
+                } catch (error) {
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                }
+              }
+            }
+
+            async function setStatus(label) {
+              await removeStatusLabels();
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: [label],
+              });
+            }
+
+            async function commentOnce(marker, body) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              const existing = comments.find((comment) => comment.body?.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }
+
+            async function getFileSha(path) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path,
+                  ref: defaultBranch,
+                });
+                return Array.isArray(data) ? undefined : data.sha;
+              } catch (error) {
+                if (error.status === 404) {
+                  return undefined;
+                }
+                throw error;
+              }
+            }
+
+            async function writeJsonFile(path, data, message) {
+              const sha = await getFileSha(path);
+              const content = Buffer.from(`${JSON.stringify(data, null, 2)}\n`, "utf8").toString("base64");
+
+              await github.rest.repos.createOrUpdateFileContents({
+                owner,
+                repo,
+                path,
+                message,
+                content,
+                sha,
+                branch: defaultBranch,
+              });
+            }
+
+            function signupRecordPath(username) {
+              return `data/signups/${signupYear}/${username.toLowerCase()}.json`;
+            }
+
+            function formatRepositoryList(repositories) {
+              if (!repositories.length) {
+                return [
+                  "- 暂无。实验仓库创建、fork 和授权步骤接入后会更新报名记录和本评论。",
+                ];
+              }
+
+              return repositories.map((repository) => {
+                const permissionText = repository.permission ? `，权限：${repository.permission}` : "";
+                return `- [${repository.name}](${repository.url})${permissionText}`;
+              });
+            }
+
+            function formatInviteNotice(repositories) {
+              if (!repositories.length) {
+                return "当前没有需要接受的仓库邀请。后续私有实验仓库创建后，请在 GitHub 通知中接受邀请。";
+              }
+
+              const hasInvitation = repositories.some((repository) => repository.invitation_required);
+              if (hasInvitation) {
+                return "如果 GitHub 发送了仓库邀请，请先在 GitHub 通知中接受邀请，然后再访问实验仓库。";
+              }
+
+              return "仓库权限已经配置完成，可以直接访问上方实验仓库链接。";
+            }
+
+            async function writeSignupRecord({ username, status, repositories, errorMessage }) {
+              const path = signupRecordPath(username);
+              const now = new Date().toISOString();
+              const record = {
+                github_username: username,
+                issue_number: issue.number,
+                issue_url: issue.html_url,
+                registered_at: issue.created_at,
+                updated_at: now,
+                repositories,
+                status,
+              };
+
+              if (errorMessage) {
+                record.error = errorMessage;
+              }
+
+              await writeJsonFile(
+                path,
+                record,
+                `docs/signup: update signup record for ${username}`
+              );
+
+              return path;
+            }
+
+            function cleanFieldValue(rawValue) {
+              return (rawValue ?? "")
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter((line) => line && !line.startsWith("<!--") && !line.startsWith("_No response_"))
+                .join(" ")
+                .replace(/^@+/, "")
+                .replace(/[`*_]/g, "")
+                .trim();
+            }
+
+            function extractUsernameFromBody(body) {
+              const headings = [...(body ?? "").matchAll(/^###\s+(.+?)\s*$/gm)];
+              for (let index = 0; index < headings.length; index += 1) {
+                const heading = headings[index];
+                const headingText = heading[1].trim().toLowerCase();
+                const isUsernameField = headingText.includes("github")
+                  && (headingText.includes("用户名") || headingText.includes("username"));
+                if (!isUsernameField) {
+                  continue;
+                }
+
+                const valueStart = heading.index + heading[0].length;
+                const valueEnd = headings[index + 1]?.index ?? body.length;
+                return cleanFieldValue(body.slice(valueStart, valueEnd));
+              }
+
+              return "";
+            }
+
+            function extractUsernameFromTitle(title) {
+              const escapedPrefix = signupTitlePrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+              const match = title.match(new RegExp(`^${escapedPrefix}\\s*@?([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)`));
+              return match?.[1] ?? "";
+            }
+
+            function normalizeUsername(username) {
+              return username.trim().replace(/^@+/, "");
+            }
+
+            function issueMentionsUsername(candidateIssue, username) {
+              const normalizedUsername = username.toLowerCase();
+              const escapedUsername = normalizedUsername.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+              const usernameRegExp = new RegExp(`(^|[^a-z0-9-])${escapedUsername}([^a-z0-9-]|$)`, "i");
+              return usernameRegExp.test(candidateIssue.title ?? "") || usernameRegExp.test(candidateIssue.body ?? "");
+            }
+
+            async function findDuplicateSignup(username) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: "all",
+                labels: "signup",
+                per_page: 100,
+              });
+
+              return issues.find((candidateIssue) => (
+                candidateIssue.number !== issueNumber
+                && !candidateIssue.pull_request
+                && !candidateIssue.labels.some((label) => ["signup/invalid", "signup/duplicate"].includes(label.name))
+                && issueMentionsUsername(candidateIssue, username)
+              ));
+            }
+
+            await Promise.all([signupLabel, ...Object.values(statusLabels)].map(ensureLabel));
+            if (!hasSignupLabel) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: [signupLabel.name],
+              });
+            }
+            await setStatus(statusLabels.processing.name);
+
+            let username = "";
+            const createdRepositories = [];
+
+            try {
+              username = normalizeUsername(
+                extractUsernameFromBody(issue.body) || extractUsernameFromTitle(issue.title)
+              );
+              const issueAuthor = issue.user.login;
+
+              if (!usernamePattern.test(username)) {
+                await setStatus(statusLabels.invalid.name);
+                await commentOnce(
+                  "<!-- signup-invalid-username -->",
+                  [
+                    "<!-- signup-invalid-username -->",
+                    "报名校验失败：GitHub 用户名格式不正确。",
+                    "",
+                    `当前解析到的用户名：\`${username || "(空)"}\``,
+                    "",
+                    "请修改 Issue 中的 GitHub 用户名后重新提交。",
+                  ].join("\n")
+                );
+                return;
+              }
+
+              try {
+                await github.rest.users.getByUsername({
+                  username,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                await setStatus(statusLabels.invalid.name);
+                await commentOnce(
+                  "<!-- signup-invalid-user-not-found -->",
+                  [
+                    "<!-- signup-invalid-user-not-found -->",
+                    "报名校验失败：没有找到这个 GitHub 用户。",
+                    "",
+                    `请确认用户名 \`${username}\` 是否拼写正确。`,
+                  ].join("\n")
+                );
+                return;
+              }
+
+              if (username.toLowerCase() !== issueAuthor.toLowerCase()) {
+                await setStatus(statusLabels.invalid.name);
+                await commentOnce(
+                  "<!-- signup-invalid-author-mismatch -->",
+                  [
+                    "<!-- signup-invalid-author-mismatch -->",
+                    "报名校验失败：Issue 创建者和填写的 GitHub 用户名不一致。",
+                    "",
+                    `Issue 创建者：\`${issueAuthor}\``,
+                    `填写的用户名：\`${username}\``,
+                    "",
+                    "请使用需要参加训练营的 GitHub 账号创建报名 Issue。",
+                  ].join("\n")
+                );
+                return;
+              }
+
+              const duplicateIssue = await findDuplicateSignup(username);
+              if (duplicateIssue) {
+                await setStatus(statusLabels.duplicate.name);
+                await commentOnce(
+                  "<!-- signup-duplicate -->",
+                  [
+                    "<!-- signup-duplicate -->",
+                    "检测到重复报名。",
+                    "",
+                    `GitHub 用户 \`${username}\` 已经提交过报名：#${duplicateIssue.number}`,
+                    "",
+                    "请不要重复提交报名 Issue。",
+                  ].join("\n")
+                );
+                return;
+              }
+
+              const recordPath = await writeSignupRecord({
+                username,
+                status: "success",
+                repositories: createdRepositories,
+              });
+
+              await setStatus(statusLabels.success.name);
+              await commentOnce(
+                "<!-- signup-success -->",
+                [
+                  "<!-- signup-success -->",
+                  "报名成功。",
+                  "",
+                  `GitHub 用户：\`${username}\``,
+                  `报名记录：\`${recordPath}\``,
+                  "",
+                  "已创建或配置的实验仓库：",
+                  ...formatRepositoryList(createdRepositories),
+                  "",
+                  formatInviteNotice(createdRepositories),
+                ].join("\n")
+              );
+            } catch (error) {
+              if (usernamePattern.test(username)) {
+                try {
+                  await writeSignupRecord({
+                    username,
+                    status: "failed",
+                    repositories: createdRepositories,
+                    errorMessage: error.message,
+                  });
+                } catch (recordError) {
+                  core.warning(`Failed to write signup failure record: ${recordError.message}`);
+                }
+              }
+
+              await setStatus(statusLabels.failed.name);
+              await commentOnce(
+                "<!-- signup-failed -->",
+                [
+                  "<!-- signup-failed -->",
+                  "报名自动化处理失败，需要维护者检查 GitHub Actions 日志。",
+                  "",
+                  `错误信息：\`${error.message}\``,
+                ].join("\n")
+              );
+              throw error;
+            }

--- a/.github/workflows/signup.yml
+++ b/.github/workflows/signup.yml
@@ -18,15 +18,13 @@ permissions:
   issues: write
 
 concurrency:
-  group: signup-${{ github.event.issue.number || inputs.issue_number }}
+  group: signup-board
   cancel-in-progress: false
 
 jobs:
   validate:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.issue.title, '[报名]')
     runs-on: ubuntu-latest
-    env:
-      SIGNUP_YEAR: "2026"
     steps:
       - name: Validate signup issue
         uses: actions/github-script@v7
@@ -38,8 +36,8 @@ jobs:
               ? Number(core.getInput("issue_number"))
               : context.payload.issue.number;
             const defaultBranch = context.payload.repository?.default_branch ?? "main";
-            let signupYear = process.env.SIGNUP_YEAR;
             const signupConfigPath = "docs/data/signup-config.json";
+            const signupPagePath = "docs/signup.md";
             const defaultClosedMessage = "QEMU 训练营报名暂未开放，请关注后续通知。";
 
             const signupLabel = {
@@ -172,21 +170,22 @@ jobs:
               });
             }
 
-            async function getFileSha(path) {
-              try {
-                const { data } = await github.rest.repos.getContent({
-                  owner,
-                  repo,
-                  path,
-                  ref: defaultBranch,
-                });
-                return Array.isArray(data) ? undefined : data.sha;
-              } catch (error) {
-                if (error.status === 404) {
-                  return undefined;
-                }
-                throw error;
+            async function readTextFile(path) {
+              const { data } = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path,
+                ref: defaultBranch,
+              });
+
+              if (Array.isArray(data)) {
+                throw new Error(`${path} is a directory.`);
               }
+
+              return {
+                sha: data.sha,
+                content: Buffer.from(data.content, data.encoding ?? "base64").toString("utf8"),
+              };
             }
 
             async function readJsonFile(path) {
@@ -222,23 +221,145 @@ jobs:
                 : defaultClosedMessage;
             }
 
-            async function writeJsonFile(path, data, message) {
-              const sha = await getFileSha(path);
-              const content = Buffer.from(`${JSON.stringify(data, null, 2)}\n`, "utf8").toString("base64");
-
+            async function writeTextFile(path, sha, content, message) {
               await github.rest.repos.createOrUpdateFileContents({
                 owner,
                 repo,
                 path,
                 message,
-                content,
                 sha,
                 branch: defaultBranch,
+                content: Buffer.from(content, "utf8").toString("base64"),
               });
             }
 
-            function signupRecordPath(username) {
-              return `data/signups/${signupYear}/${username.toLowerCase()}.json`;
+            function escapeHtml(value) {
+              return String(value)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;");
+            }
+
+            function signupBoardMarkers() {
+              return {
+                start: "<!-- signup-board:start -->",
+                end: "<!-- signup-board:end -->",
+              };
+            }
+
+            function parseSignupBoardRecords(markdown) {
+              const { start, end } = signupBoardMarkers();
+              const startIndex = markdown.indexOf(start);
+              const endIndex = markdown.indexOf(end);
+
+              if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+                throw new Error(`Signup board markers not found in ${signupPagePath}.`);
+              }
+
+              const boardHtml = markdown.slice(startIndex + start.length, endIndex);
+              const records = [];
+              const rowPattern = /<tr>[\s\S]*?<\/tr>/g;
+
+              for (const rowMatch of boardHtml.matchAll(rowPattern)) {
+                const row = rowMatch[0];
+                const usernameMatch = row.match(/https:\/\/github\.com\/([A-Za-z0-9-]{1,39})/);
+                if (!usernameMatch) {
+                  continue;
+                }
+
+                const issueMatch = row.match(/href="([^"]*\/issues\/(\d+))"/);
+                const cells = [...row.matchAll(/<td(?:\s[^>]*)?>([\s\S]*?)<\/td>/g)]
+                  .map((match) => match[1].replace(/<[^>]*>/g, "").trim());
+
+                records.push({
+                  github_username: usernameMatch[1],
+                  registered_at: cells[2] || "-",
+                  issue_url: issueMatch?.[1] || "",
+                  issue_number: issueMatch?.[2] ? Number(issueMatch[2]) : undefined,
+                });
+              }
+
+              return records;
+            }
+
+            function renderSignupBoardRows(records) {
+              if (!records.length) {
+                return "        <tr>\n          <td colspan=\"4\">暂无报名记录。</td>\n        </tr>";
+              }
+
+              return records.map((record, index) => {
+                const username = escapeHtml(record.github_username);
+                const registeredAt = escapeHtml(record.registered_at || "-");
+                const issueUrl = record.issue_url || "";
+                const issueText = record.issue_number ? `#${record.issue_number}` : "查看";
+                const issueCell = issueUrl
+                  ? `<a href=\"${escapeHtml(issueUrl)}\" rel=\"noopener\">${escapeHtml(issueText)}</a>`
+                  : "-";
+
+                return [
+                  "        <tr>",
+                  `          <td>${index + 1}</td>`,
+                  `          <td><a href=\"https://github.com/${username}\" rel=\"noopener\">${username}</a></td>`,
+                  `          <td>${registeredAt}</td>`,
+                  `          <td>${issueCell}</td>`,
+                  "        </tr>",
+                ].join("\n");
+              }).join("\n");
+            }
+
+            async function updateSignupBoard({ username, issueUrl, issueNumber }) {
+              const { sha, content } = await readTextFile(signupPagePath);
+              const records = parseSignupBoardRecords(content);
+              const existingRecord = records.find((record) => record.github_username.toLowerCase() === username.toLowerCase());
+              const now = new Date().toISOString();
+
+              if (existingRecord) {
+                if (existingRecord.issue_number === issueNumber) {
+                  return { path: signupPagePath, updated: false };
+                }
+
+                throw new Error(`GitHub user ${username} already exists in signup board.`);
+              }
+
+              records.push({
+                github_username: username,
+                registered_at: now,
+                issue_url: issueUrl,
+                issue_number: issueNumber,
+              });
+              records.sort((left, right) => left.github_username.localeCompare(right.github_username, "en", { sensitivity: "base" }));
+
+              const { start, end } = signupBoardMarkers();
+              const startIndex = content.indexOf(start);
+              const endIndex = content.indexOf(end);
+              const nextBoard = `${start}\n${renderSignupBoardRows(records)}\n        ${end}`;
+              let nextContent = `${content.slice(0, startIndex)}${nextBoard}${content.slice(endIndex + end.length)}`;
+              nextContent = nextContent.replace(
+                /<strong id="signup-board-count" class="signup-board__count">\d+<\/strong>/,
+                `<strong id="signup-board-count" class="signup-board__count">${records.length}</strong>`
+              );
+
+              await writeTextFile(
+                signupPagePath,
+                sha,
+                nextContent,
+                `docs/signup: add ${username} to signup board`
+              );
+
+              return { path: signupPagePath, updated: true };
+            }
+
+            async function dispatchSignupBoardUpdated({ username, issueNumber }) {
+              await github.rest.repos.createDispatchEvent({
+                owner,
+                repo,
+                event_type: "signup-board-updated",
+                client_payload: {
+                  username,
+                  issue_number: issueNumber,
+                },
+              });
             }
 
             function formatRepositoryList(repositories) {
@@ -265,32 +386,6 @@ jobs:
               }
 
               return "仓库权限已经配置完成，可以直接访问上方实验仓库链接。";
-            }
-
-            async function writeSignupRecord({ username, status, repositories, errorMessage }) {
-              const path = signupRecordPath(username);
-              const now = new Date().toISOString();
-              const record = {
-                github_username: username,
-                issue_number: issue.number,
-                issue_url: issue.html_url,
-                registered_at: issue.created_at,
-                updated_at: now,
-                repositories,
-                status,
-              };
-
-              if (errorMessage) {
-                record.error = errorMessage;
-              }
-
-              await writeJsonFile(
-                path,
-                record,
-                `docs/signup: update signup record for ${username}`
-              );
-
-              return path;
             }
 
             function cleanFieldValue(rawValue) {
@@ -368,7 +463,6 @@ jobs:
             }
 
             const signupConfig = await readJsonFile(signupConfigPath);
-            signupYear = String(signupConfig.year || signupYear);
             if (signupConfig.enabled === false) {
               const closedMessage = signupClosedMessage(signupConfig);
               await setStatus(statusLabels.closed.name);
@@ -467,11 +561,18 @@ jobs:
                 return;
               }
 
-              const recordPath = await writeSignupRecord({
+              const boardUpdate = await updateSignupBoard({
                 username,
-                status: "success",
-                repositories: createdRepositories,
+                issueUrl: issue.html_url,
+                issueNumber: issue.number,
               });
+
+              if (boardUpdate.updated) {
+                await dispatchSignupBoardUpdated({
+                  username,
+                  issueNumber: issue.number,
+                });
+              }
 
               await setStatus(statusLabels.success.name);
               await commentOnce(
@@ -481,7 +582,7 @@ jobs:
                   "报名成功。",
                   "",
                   `GitHub 用户：\`${username}\``,
-                  `报名记录：\`${recordPath}\``,
+                  `报名看板：\`${boardUpdate.path}\``,
                   "",
                   "已创建或配置的实验仓库：",
                   ...formatRepositoryList(createdRepositories),
@@ -490,19 +591,6 @@ jobs:
                 ].join("\n")
               );
             } catch (error) {
-              if (usernamePattern.test(username)) {
-                try {
-                  await writeSignupRecord({
-                    username,
-                    status: "failed",
-                    repositories: createdRepositories,
-                    errorMessage: error.message,
-                  });
-                } catch (recordError) {
-                  core.warning(`Failed to write signup failure record: ${recordError.message}`);
-                }
-              }
-
               await setStatus(statusLabels.failed.name);
               await commentOnce(
                 "<!-- signup-failed -->",

--- a/docs/data/signup-config.json
+++ b/docs/data/signup-config.json
@@ -1,0 +1,5 @@
+{
+  "enabled": true,
+  "year": "2026",
+  "closed_message": "QEMU 训练营报名暂未开放，请关注后续通知。"
+}

--- a/docs/data/signup-config.json
+++ b/docs/data/signup-config.json
@@ -1,5 +1,4 @@
 {
   "enabled": true,
-  "year": "2026",
   "closed_message": "QEMU 训练营报名暂未开放，请关注后续通知。"
 }

--- a/docs/plugins/stylesheets/extra.css
+++ b/docs/plugins/stylesheets/extra.css
@@ -70,3 +70,83 @@ article p {
 .md-sidebar--secondary [data-md-component="toc"] li.md-nav__item[data-toc-expanded="true"] > button.md-toc__toggle::before {
   transform: rotate(90deg);
 }
+
+.signup-form {
+  margin: 1.2rem 0 1.6rem;
+}
+
+.signup-form label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 700;
+}
+
+.signup-form__row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: stretch;
+  max-width: 36rem;
+}
+
+.signup-form input {
+  min-width: 0;
+  flex: 1 1 auto;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.2rem;
+  color: var(--md-default-fg-color);
+  background: var(--md-default-bg-color);
+  font: inherit;
+}
+
+.signup-form input:focus {
+  border-color: var(--md-accent-fg-color);
+  outline: 2px solid color-mix(in srgb, var(--md-accent-fg-color) 24%, transparent);
+  outline-offset: 1px;
+}
+
+.signup-form .md-button {
+  flex: 0 0 auto;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.signup-form .md-button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.signup-form__status {
+  max-width: 36rem;
+  margin: 0.55rem 0 0;
+  font-size: 0.8rem;
+}
+
+.signup-form__status--info {
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .signup-form__status--error {
+  color: #ff3b30 !important;
+}
+
+.md-typeset .signup-form__status--error a {
+  color: #ff3b30 !important;
+  text-decoration-color: currentColor;
+}
+
+.signup-form__status a {
+  color: inherit;
+  font-weight: 700;
+}
+
+@media screen and (max-width: 36rem) {
+  .signup-form__row {
+    flex-direction: column;
+  }
+
+  .signup-form .md-button {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/docs/plugins/stylesheets/extra.css
+++ b/docs/plugins/stylesheets/extra.css
@@ -140,6 +140,52 @@ article p {
   font-weight: 700;
 }
 
+.signup-board {
+  margin: 1.2rem 0 1.8rem;
+}
+
+.signup-board__summary {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  max-width: 48rem;
+  margin-bottom: 0.75rem;
+}
+
+.signup-board__summary h3 {
+  margin: 0 0 0.2rem;
+}
+
+.signup-board__status {
+  margin: 0;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.8rem;
+}
+
+.signup-board__count {
+  min-width: 3rem;
+  color: var(--md-accent-fg-color);
+  font-size: 2rem;
+  line-height: 1;
+  text-align: right;
+}
+
+.signup-board__table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.signup-board__table {
+  min-width: 42rem;
+}
+
+.signup-board__table th:first-child,
+.signup-board__table td:first-child {
+  width: 3rem;
+  text-align: right;
+}
+
 @media screen and (max-width: 36rem) {
   .signup-form__row {
     flex-direction: column;
@@ -148,5 +194,14 @@ article p {
   .signup-form .md-button {
     width: 100%;
     text-align: center;
+  }
+
+  .signup-board__summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .signup-board__count {
+    text-align: left;
   }
 }

--- a/docs/signup.md
+++ b/docs/signup.md
@@ -1,0 +1,166 @@
+# QEMU 训练营报名
+
+欢迎报名 QEMU 训练营。当前报名只需要确认 GitHub 用户名。系统会以报名表中填写的 GitHub 用户名作为后续实验仓库的授权账号。
+
+!!! warning "公开信息提醒"
+
+    当前报名表通过 GitHub Issue Form 提交，报名内容会出现在公开 Issue 中。请不要填写手机号、邮箱、身份证号等隐私信息。
+
+<form id="signup-form" class="signup-form">
+  <label for="github-username">GitHub 用户名</label>
+  <div class="signup-form__row">
+    <input
+      id="github-username"
+      name="github_username"
+      type="text"
+      autocomplete="username"
+      maxlength="39"
+      pattern="[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?"
+      placeholder="例如：bbbbbq"
+      required
+    />
+    <button type="submit" class="md-button md-button--primary">立即报名</button>
+  </div>
+  <p id="signup-status" class="signup-form__status" aria-live="polite" hidden></p>
+</form>
+
+<noscript>
+  <p>
+    <a class="md-button md-button--primary" href="https://github.com/gevico/qemu-camp-tutorial/issues/new?template=signup.yml">立即报名</a>
+  </p>
+</noscript>
+
+!!! note "报名后会发生什么"
+
+    点击“立即报名”后会跳转到 GitHub Issue Form。请在 GitHub 页面确认并提交 Issue。
+
+    报名 Issue 会带有 `[报名]` 标题前缀和 `signup` 标签，后续可由报名仓库或子仓库中的 CI/CD 识别并执行自动化流程，包括记录报名信息、创建或 fork 实验仓库，并为报名账号配置仓库权限。
+
+!!! tip "填写前请确认"
+
+    - 已登录自己的 GitHub 账号。
+    - 填写的 GitHub 用户名就是后续完成实验和提交作业的账号。
+    - 如果需要更换 GitHub 账号，请重新使用正确账号提交报名。
+
+<script>
+(() => {
+  const form = document.getElementById("signup-form");
+  const input = document.getElementById("github-username");
+  const status = document.getElementById("signup-status");
+  const submitButton = form?.querySelector("button[type='submit']");
+
+  if (!form || !input) {
+    return;
+  }
+
+  const setStatus = (message, kind = "info", link) => {
+    if (!status) {
+      return;
+    }
+
+    status.hidden = false;
+    status.className = `signup-form__status signup-form__status--${kind}`;
+    status.textContent = message;
+
+    if (link) {
+      status.append(" ");
+      const anchor = document.createElement("a");
+      anchor.href = link;
+      anchor.textContent = "查看已有报名";
+      anchor.rel = "noopener";
+      status.append(anchor);
+    }
+  };
+
+  const issueMentionsUsername = (issue, username) => {
+    const normalizedUsername = username.toLowerCase();
+    const title = issue.title?.trim().toLowerCase() ?? "";
+    const body = issue.body?.toLowerCase() ?? "";
+    const usernamePattern = new RegExp(`(^|[^a-z0-9-])${normalizedUsername.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([^a-z0-9-]|$)`);
+
+    return usernamePattern.test(title) || usernamePattern.test(body);
+  };
+
+  const isIgnoredSignupIssue = (issue) => {
+    const ignoredLabels = new Set(["signup/invalid", "signup/duplicate"]);
+    const hasIgnoredLabel = (issue.labels ?? []).some((label) => ignoredLabels.has(label.name ?? label));
+
+    return Boolean(issue.pull_request) || hasIgnoredLabel;
+  };
+
+  const findExistingSignup = async (username) => {
+    let apiUrl = "https://api.github.com/repos/gevico/qemu-camp-tutorial/issues?state=all&labels=signup&per_page=100";
+    let pageCount = 0;
+
+    while (apiUrl && pageCount < 10) {
+      pageCount += 1;
+      const response = await fetch(apiUrl, {
+        headers: {
+          Accept: "application/vnd.github+json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`GitHub API returned ${response.status}`);
+      }
+
+      const issues = await response.json();
+      const existingIssue = issues.find((issue) => (
+        !isIgnoredSignupIssue(issue) && issueMentionsUsername(issue, username)
+      ));
+
+      if (existingIssue) {
+        return existingIssue;
+      }
+
+      const linkHeader = response.headers.get("Link") ?? "";
+      const nextLink = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+      apiUrl = nextLink?.[1] ?? "";
+    }
+
+    return null;
+  };
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = input.value.trim().replace(/^@+/, "");
+    const validUsername = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(username);
+
+    if (!validUsername) {
+      input.setCustomValidity("请输入有效的 GitHub 用户名");
+      input.reportValidity();
+      return;
+    }
+
+    input.setCustomValidity("");
+    submitButton?.setAttribute("disabled", "disabled");
+    setStatus("正在检查是否已经报名...");
+
+    const params = new URLSearchParams({
+      template: "signup.yml",
+      title: `[报名] ${username}`,
+      github_username: username,
+    });
+    const signupUrl = `https://github.com/gevico/qemu-camp-tutorial/issues/new?${params.toString()}`;
+
+    try {
+      const existingIssue = await findExistingSignup(username);
+
+      if (existingIssue) {
+        setStatus(`GitHub 用户名 ${username} 已经提交过报名，请不要重复提交。`, "error", existingIssue.html_url);
+        return;
+      }
+
+      setStatus("未发现重复报名，正在跳转到 GitHub...");
+      window.location.href = signupUrl;
+    } catch (error) {
+      console.error(error);
+      setStatus("暂时无法检查重复报名，正在跳转到 GitHub...");
+      window.location.href = signupUrl;
+    } finally {
+      submitButton?.removeAttribute("disabled");
+    }
+  });
+})();
+</script>

--- a/docs/signup.md
+++ b/docs/signup.md
@@ -42,6 +42,37 @@
     - 填写的 GitHub 用户名就是后续完成实验和提交作业的账号。
     - 如果需要更换 GitHub 账号，请重新使用正确账号提交报名。
 
+## 已报名学员
+
+<section class="signup-board" aria-labelledby="signup-board-title">
+  <div class="signup-board__summary">
+    <div>
+      <h3 id="signup-board-title">报名看板</h3>
+      <p class="signup-board__status">报名成功后自动更新。</p>
+    </div>
+    <strong id="signup-board-count" class="signup-board__count">0</strong>
+  </div>
+  <div class="signup-board__table-wrap">
+    <table class="signup-board__table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>GitHub ID</th>
+          <th>报名时间</th>
+          <th>Issue</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- signup-board:start -->
+        <tr>
+          <td colspan="4">暂无报名记录。</td>
+        </tr>
+        <!-- signup-board:end -->
+      </tbody>
+    </table>
+  </div>
+</section>
+
 <script>
 (() => {
   const form = document.getElementById("signup-form");

--- a/docs/signup.md
+++ b/docs/signup.md
@@ -48,10 +48,14 @@
   const input = document.getElementById("github-username");
   const status = document.getElementById("signup-status");
   const submitButton = form?.querySelector("button[type='submit']");
+  let signupEnabled = false;
 
   if (!form || !input) {
     return;
   }
+
+  input.disabled = true;
+  submitButton?.setAttribute("disabled", "disabled");
 
   const setStatus = (message, kind = "info", link) => {
     if (!status) {
@@ -79,6 +83,32 @@
     const usernamePattern = new RegExp(`(^|[^a-z0-9-])${normalizedUsername.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([^a-z0-9-]|$)`);
 
     return usernamePattern.test(title) || usernamePattern.test(body);
+  };
+
+  const setSignupEnabled = (enabled, message) => {
+    signupEnabled = enabled;
+
+    input.disabled = !enabled;
+    submitButton?.toggleAttribute("disabled", !enabled);
+
+    if (!enabled) {
+      setStatus(message || "QEMU 训练营报名暂未开放，请关注后续通知。");
+    }
+  };
+
+  const loadSignupConfig = async () => {
+    const response = await fetch("../data/signup-config.json", {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Signup config returned ${response.status}`);
+    }
+
+    return response.json();
   };
 
   const isIgnoredSignupIssue = (issue) => {
@@ -124,6 +154,11 @@
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!signupEnabled) {
+      setStatus("正在读取报名状态，请稍后再试。", "error");
+      return;
+    }
+
     const username = input.value.trim().replace(/^@+/, "");
     const validUsername = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(username);
 
@@ -159,8 +194,17 @@
       setStatus("暂时无法检查重复报名，正在跳转到 GitHub...");
       window.location.href = signupUrl;
     } finally {
-      submitButton?.removeAttribute("disabled");
+      submitButton?.toggleAttribute("disabled", !signupEnabled);
     }
   });
+
+  loadSignupConfig()
+    .then((config) => {
+      setSignupEnabled(config.enabled !== false, config.closed_message);
+    })
+    .catch((error) => {
+      console.error(error);
+      setStatus("暂时无法读取报名状态，请刷新页面后重试。", "error");
+    });
 })();
 </script>

--- a/docs/signup.md
+++ b/docs/signup.md
@@ -142,11 +142,27 @@
     return response.json();
   };
 
-  const isIgnoredSignupIssue = (issue) => {
-    const ignoredLabels = new Set(["signup/invalid", "signup/duplicate"]);
-    const hasIgnoredLabel = (issue.labels ?? []).some((label) => ignoredLabels.has(label.name ?? label));
+  const isPullRequestIssue = (issue) => Boolean(issue.pull_request);
 
-    return Boolean(issue.pull_request) || hasIgnoredLabel;
+  const findExistingSignupInBoard = (username) => {
+    const normalizedUsername = username.toLowerCase();
+    const rows = document.querySelectorAll(".signup-board__table tbody tr");
+
+    for (const row of rows) {
+      const usernameLink = row.cells?.[1]?.querySelector("a[href^='https://github.com/']");
+      const boardUsername = usernameLink?.textContent?.trim().toLowerCase();
+
+      if (boardUsername !== normalizedUsername) {
+        continue;
+      }
+
+      const issueLink = row.querySelector("a[href*='/issues/']");
+      return {
+        html_url: issueLink?.href || usernameLink.href,
+      };
+    }
+
+    return null;
   };
 
   const findExistingSignup = async (username) => {
@@ -167,7 +183,7 @@
 
       const issues = await response.json();
       const existingIssue = issues.find((issue) => (
-        !isIgnoredSignupIssue(issue) && issueMentionsUsername(issue, username)
+        !isPullRequestIssue(issue) && issueMentionsUsername(issue, username)
       ));
 
       if (existingIssue) {
@@ -211,6 +227,13 @@
     const signupUrl = `https://github.com/gevico/qemu-camp-tutorial/issues/new?${params.toString()}`;
 
     try {
+      const existingBoardSignup = findExistingSignupInBoard(username);
+
+      if (existingBoardSignup) {
+        setStatus(`GitHub 用户名 ${username} 已经提交过报名，请不要重复提交。`, "error", existingBoardSignup.html_url);
+        return;
+      }
+
       const existingIssue = await findExistingSignup(username);
 
       if (existingIssue) {

--- a/docs/tutorial/2026/index.md
+++ b/docs/tutorial/2026/index.md
@@ -4,7 +4,7 @@
 
     QEMU 训练营是在清华大学陈渝老师和李明老师的倡议下，由格维开源社区 (GTOC) 发起的公益性技术训练营，旨在搭建一个虚拟化/模拟器技术学习与实践平台，助力开发者深入掌握 QEMU 核心能力，推动开源生态发展。本期 QEMU 训练营（2026）由[格维开源社区][gevico-link]和[华中科技大学开放原子开源俱乐部][hust-openatom-club-link]主办。合作单位有 [OpenCamp 社区][opencamp-link]、[苦芽科技][kubuds-link]、[甲辰计划][rv2036-link]。
 
-[☞ 线上报名通道 ☄](https://opencamp.cn/gevico/camp/2026/register?code=d6EdXAxro0eFJ)
+[☞ 线上报名通道 ☄](../../signup.md)
 
 
 [gevico-link]: https://github.com/gevico

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ extra_javascript:
 
 nav:
   - 主页: index.md
+  - 报名: signup.md
   - 讲义:
     - QEMU 训练营 2026:
       - 训练营介绍: tutorial/2026/index.md


### PR DESCRIPTION
Add basic sign-up functionality. The ideal workflow involves clicking a sign-up link to navigate to the issue creation page; upon issue creation, a CI/CD process is triggered to handle subsequent tasks, such as forking the repository.