### PR TITLE
docs: update copyright organization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 华中科技大学开放原子开源俱乐部
+Copyright (c) 2024 Gevico Tech Open Community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## 关联章节/文件
- 许可证：`LICENSE`

## 修改类型
- [x] 其他：MIT copyright 更新

## 修改描述
- 将 `LICENSE` 中的 MIT copyright holder 从 `华中科技大学开放原子开源俱乐部` 更新为 `Gevico Tech Open Community`。

## 本地验证
- [x] `make build`
- [x] `git diff --check`