### PR TITLE
docs: improve leaderboard presentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -598,8 +598,12 @@ body:has(.home-page) .md-content__inner > h1:first-child {
   <section class="home-section">
     <div class="home-section__head">
       <h2>最新动态</h2>
-      <a href="news/2026/qemu-camp-meetup-2026-04-05/">更多</a>
+      <a href="news/2026/qemu-camp-project-stage-2026-07-03/">更多</a>
     </div>
+    <a class="home-list-item" href="news/2026/qemu-camp-project-stage-2026-07-03/">
+      <span>QEMU 训练营 2026 项目阶段正式开启</span>
+      <small>2026.07.03</small>
+    </a>
     <a class="home-list-item" href="news/2026/qemu-camp-meetup-2026-04-05/">
       <span>启航！QEMU 训练营 2026 开营，深耕虚拟化与体系结构教学新征程</span>
       <small>2026.04.05</small>
@@ -619,10 +623,6 @@ body:has(.home-page) .md-content__inner > h1:first-child {
     <a class="home-list-item" href="news/2026/qemu-camp-meetup-2026-01-30/">
       <span>QEMU 训练营 2026 第一次工作推进会顺利召开，各项筹备有序落地</span>
       <small>2026.01.30</small>
-    </a>
-    <a class="home-list-item" href="news/2026/qemu-camp-update-2026-01-07/">
-      <span>关于 QEMU 训练营 2026 正式启动筹备工作的通知</span>
-      <small>2026.01.07</small>
     </a>
   </section>
 

--- a/docs/leaderboards/2026/basic/c.md
+++ b/docs/leaderboards/2026/basic/c.md
@@ -1,124 +1,967 @@
 # QEMU 训练营 2026 基础阶段 C 语言排行榜
 
-[**C 语言**](c.md) | [Rust](rust.md)
+<nav class="qemu-leaderboard-tabs" aria-label="排行榜切换">
+  <a class="qemu-leaderboard-tabs__item is-active" href="c.md" aria-current="page">C 语言</a>
+  <a class="qemu-leaderboard-tabs__item" href="rust.md">Rust</a>
+</nav>
 
-| 排名 | GitHub ID | 得分 | 总分 | 评分 run 时间 |
-| --- | --- | ---: | ---: | --- |
-| 1 | random25160765-collab | 200 | 200 | 2026-04-07 09:02 UTC |
-| 2 | Codeman-1999 | 200 | 200 | 2026-04-08 04:47 UTC |
-| 3 | fbt1709 | 200 | 200 | 2026-04-08 06:24 UTC |
-| 4 | ihanzh | 200 | 200 | 2026-04-08 15:38 UTC |
-| 5 | nusakom | 200 | 200 | 2026-04-08 21:13 UTC |
-| 6 | srcres258 | 200 | 200 | 2026-04-10 16:38 UTC |
-| 7 | seehello | 200 | 200 | 2026-04-11 11:28 UTC |
-| 8 | shangguanyongshi | 200 | 200 | 2026-04-15 00:45 UTC |
-| 9 | flamboyante | 200 | 200 | 2026-04-15 02:40 UTC |
-| 10 | LiuHongsGitHub | 200 | 200 | 2026-04-16 03:42 UTC |
-| 11 | Aozaki-aok0 | 200 | 200 | 2026-04-16 15:09 UTC |
-| 12 | clsfantasy | 200 | 200 | 2026-04-17 07:52 UTC |
-| 13 | Sutter099 | 200 | 200 | 2026-04-17 10:40 UTC |
-| 14 | vsvnakers | 200 | 200 | 2026-04-17 19:41 UTC |
-| 15 | GrexLoong | 200 | 200 | 2026-04-19 15:10 UTC |
-| 16 | trace1729 | 200 | 200 | 2026-04-21 07:40 UTC |
-| 17 | RainLeaf16 | 200 | 200 | 2026-04-25 15:08 UTC |
-| 18 | primercoder | 200 | 200 | 2026-04-27 00:27 UTC |
-| 19 | littlewangzai-orz | 200 | 200 | 2026-04-27 06:52 UTC |
-| 20 | asdfgh870 | 200 | 200 | 2026-04-30 14:33 UTC |
-| 21 | lingqian-gi | 200 | 200 | 2026-05-02 12:52 UTC |
-| 22 | eternal-echo | 200 | 200 | 2026-05-03 08:00 UTC |
-| 23 | helloyuze | 200 | 200 | 2026-05-07 14:52 UTC |
-| 24 | First-da | 200 | 200 | 2026-05-08 08:50 UTC |
-| 25 | xiaoerlang0359-debug | 200 | 200 | 2026-05-10 13:10 UTC |
-| 26 | 73fc | 200 | 200 | 2026-05-10 14:20 UTC |
-| 27 | SSJ-ZYJ | 200 | 200 | 2026-05-11 15:50 UTC |
-| 28 | serf-huik | 200 | 200 | 2026-05-17 09:03 UTC |
-| 29 | GaryHu-zzz | 200 | 200 | 2026-05-18 13:51 UTC |
-| 30 | srhashdh | 200 | 200 | 2026-05-20 05:42 UTC |
-| 31 | 2zuqisong | 200 | 200 | 2026-05-25 13:55 UTC |
-| 32 | qinzhengxiang | 200 | 200 | 2026-05-28 13:31 UTC |
-| 33 | xiex386 | 200 | 200 | 2026-05-30 03:14 UTC |
-| 34 | jieniguiemmm | 200 | 200 | 2026-06-05 11:23 UTC |
-| 35 | WhiteBearI | 200 | 200 | 2026-06-07 23:53 UTC |
-| 36 | yyxt-xwy | 200 | 200 | 2026-06-08 13:39 UTC |
-| 37 | Gmikele | 200 | 200 | 2026-06-12 00:15 UTC |
-| 38 | endwhiteparadox | 200 | 200 | 2026-06-12 09:44 UTC |
-| 39 | Sunuywq | 200 | 200 | 2026-06-15 13:22 UTC |
-| 40 | nv3ifu | 200 | 200 | 2026-06-21 08:55 UTC |
-| 41 | dweeqhd | 200 | 200 | 2026-06-28 16:04 UTC |
-| 42 | apolecoco | 200 | 200 | 2026-07-06 13:46 UTC |
-| 43 | yunyi1201 | 195 | 200 | 2026-04-11 13:39 UTC |
-| 44 | meat00 | 195 | 200 | 2026-04-12 09:58 UTC |
-| 45 | LNfromNorth | 195 | 200 | 2026-04-18 06:43 UTC |
-| 46 | adgnaf | 195 | 200 | 2026-04-22 08:08 UTC |
-| 47 | yummy0406 | 195 | 200 | 2026-04-22 16:52 UTC |
-| 48 | BoBoDai | 195 | 200 | 2026-04-25 17:40 UTC |
-| 49 | Kirito-yhh | 195 | 200 | 2026-04-26 15:13 UTC |
-| 50 | Opadc | 195 | 200 | 2026-05-05 14:09 UTC |
-| 51 | EmissaryD | 195 | 200 | 2026-05-08 16:01 UTC |
-| 52 | gulangyuzzz | 195 | 200 | 2026-05-09 15:39 UTC |
-| 53 | lebenito030 | 195 | 200 | 2026-05-14 06:09 UTC |
-| 54 | jensenojs | 195 | 200 | 2026-05-14 13:35 UTC |
-| 55 | yuanyiboyyb | 195 | 200 | 2026-05-17 15:56 UTC |
-| 56 | Egg12138 | 195 | 200 | 2026-06-01 17:34 UTC |
-| 57 | lukamriccc | 195 | 200 | 2026-06-02 10:09 UTC |
-| 58 | after1990s | 195 | 200 | 2026-06-07 13:33 UTC |
-| 59 | NewFei | 195 | 200 | 2026-06-13 09:25 UTC |
-| 60 | yyf2050567-afk | 195 | 200 | 2026-06-28 12:54 UTC |
-| 61 | Old-cpu | 195 | 200 | 2026-07-06 09:08 UTC |
-| 62 | manbo1234 | 190 | 200 | 2026-04-20 12:30 UTC |
-| 63 | ZHIKAIQ1998 | 190 | 200 | 2026-05-26 15:50 UTC |
-| 64 | cecho9992-boop | 190 | 200 | 2026-07-03 01:43 UTC |
-| 65 | destinyFvcker | 180 | 200 | 2026-04-12 03:35 UTC |
-| 66 | oscizk | 180 | 200 | 2026-05-08 15:28 UTC |
-| 67 | yeyumeng7799 | 120 | 200 | 2026-05-16 05:04 UTC |
-| 68 | HelloLiYifei | 115 | 200 | 2026-05-12 10:06 UTC |
-| 69 | chrisynl | 100 | 200 | 2026-04-12 15:54 UTC |
-| 70 | xxluestc | 100 | 200 | 2026-04-16 12:01 UTC |
-| 71 | xwwcyber | 100 | 200 | 2026-05-10 06:04 UTC |
-| 72 | lemonsuqing | 95 | 200 | 2026-04-15 09:12 UTC |
-| 73 | ghostdragonzero | 95 | 200 | 2026-04-21 09:47 UTC |
-| 74 | dazuo233 | 95 | 200 | 2026-04-23 10:00 UTC |
-| 75 | Idonotno | 95 | 200 | 2026-04-30 03:21 UTC |
-| 76 | firecrack | 95 | 200 | 2026-07-04 15:29 UTC |
-| 77 | akikaede6 | 90 | 200 | 2026-05-09 09:56 UTC |
-| 78 | yzqyzqyzq-git | 90 | 200 | 2026-05-16 10:13 UTC |
-| 79 | csdjr | 90 | 200 | 2026-05-29 16:34 UTC |
-| 80 | zhenbaii | 85 | 200 | 2026-04-09 09:54 UTC |
-| 81 | RubMaker | 85 | 200 | 2026-04-10 09:37 UTC |
-| 82 | luis-233 | 80 | 200 | 2026-04-14 08:53 UTC |
-| 83 | Hokfs | 80 | 200 | 2026-04-28 07:31 UTC |
-| 84 | 0ranan | 80 | 200 | 2026-05-02 09:37 UTC |
-| 85 | h1y2g3l4y5 | 70 | 200 | 2026-04-17 16:27 UTC |
-| 86 | KeyBor | 60 | 200 | 2026-04-06 14:34 UTC |
-| 87 | yunjianshijie | 60 | 200 | 2026-04-26 09:55 UTC |
-| 88 | 55Curry | 55 | 200 | 2026-04-22 13:00 UTC |
-| 89 | SiYue-ZO | 50 | 200 | 2026-04-26 13:41 UTC |
-| 90 | AtomAlpaca | 50 | 200 | 2026-06-17 10:42 UTC |
-| 91 | zhu30844 | 45 | 200 | 2026-04-07 06:10 UTC |
-| 92 | Beatrice0377 | 40 | 200 | 2026-04-16 10:41 UTC |
-| 93 | enlist12 | 35 | 200 | 2026-04-09 06:27 UTC |
-| 94 | huclimb | 35 | 200 | 2026-05-10 15:25 UTC |
-| 95 | SinnLiu | 35 | 200 | 2026-05-17 14:49 UTC |
-| 96 | keepgoong | 30 | 200 | 2026-06-23 14:42 UTC |
-| 97 | Lcollection | 25 | 200 | 2026-04-19 22:08 UTC |
-| 98 | Sleepless9 | 25 | 200 | 2026-04-23 09:26 UTC |
-| 99 | ZT0717 | 20 | 200 | 2026-04-17 12:10 UTC |
-| 100 | GreyFoox | 20 | 200 | 2026-04-30 06:47 UTC |
-| 101 | chennuo927 | 20 | 200 | 2026-05-10 07:18 UTC |
-| 102 | ZhonghuaQi | 15 | 200 | 2026-06-05 10:19 UTC |
-| 103 | ye-rm | 10 | 200 | 2026-04-06 13:37 UTC |
-| 104 | WCMS688 | 10 | 200 | 2026-04-16 11:19 UTC |
-| 105 | DiQing2007 | 10 | 200 | 2026-04-20 17:12 UTC |
-| 106 | xiaozhuABCD1234 | 10 | 200 | 2026-05-18 03:04 UTC |
-| 107 | bbbbbq | 5 | 200 | 2026-04-08 16:40 UTC |
-| 108 | heichiii | 5 | 200 | 2026-04-12 21:10 UTC |
-| 109 | ctdrm | 5 | 200 | 2026-04-13 10:36 UTC |
-| 110 | Eclipse-Arrebol | 5 | 200 | 2026-04-13 13:42 UTC |
-| 111 | Eclipse-yanluo | 5 | 200 | 2026-04-14 03:51 UTC |
-| 112 | duckchih | 5 | 200 | 2026-04-26 13:38 UTC |
-| 113 | lusixing | 5 | 200 | 2026-04-27 07:55 UTC |
-| 114 | weypro | 5 | 200 | 2026-05-01 15:28 UTC |
-| 115 | zhang-san-007 | 5 | 200 | 2026-05-08 15:18 UTC |
-| 116 | aaaaqweaaaa | 0 | 200 | 2026-04-24 10:56 UTC |
-
-每天刷新一次｜快照生成时间：2026-07-08 20:50 UTC
+<section class="qemu-leaderboard" aria-label="排行榜">
+  <div class="qemu-leaderboard__header">
+    <div>
+      <div class="qemu-leaderboard__title">基础阶段 · C 语言</div>
+      <div class="qemu-leaderboard__subtitle">每天刷新一次</div>
+    </div>
+    <div class="qemu-leaderboard__updated">快照生成时间：2026-07-09 14:39 UTC</div>
+  </div>
+  <div class="qemu-leaderboard__metrics">
+    <div class="qemu-leaderboard__metric qemu-leaderboard__metric--primary">
+      <span class="qemu-leaderboard__metric-value">116</span>
+      <span class="qemu-leaderboard__metric-label">上榜人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">42</span>
+      <span class="qemu-leaderboard__metric-label">满分人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">200/200</span>
+      <span class="qemu-leaderboard__metric-label">最高得分</span>
+    </div>
+  </div>
+  <div class="qemu-leaderboard__scroll">
+    <div class="qemu-leaderboard__list-head" aria-hidden="true">
+      <span>排名</span>
+      <span>GitHub ID</span>
+      <span>得分</span>
+    </div>
+    <ol class="qemu-leaderboard__rows">
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="1" data-github-id="random25160765-collab" data-score="200" data-total-score="200" data-run-time="2026-04-07 09:02 UTC">
+        <span class="qemu-leaderboard__rank">1</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/random25160765-collab" target="_blank" rel="noopener noreferrer">random25160765-collab</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="2" data-github-id="Codeman-1999" data-score="200" data-total-score="200" data-run-time="2026-04-08 04:47 UTC">
+        <span class="qemu-leaderboard__rank">2</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Codeman-1999" target="_blank" rel="noopener noreferrer">Codeman-1999</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="3" data-github-id="fbt1709" data-score="200" data-total-score="200" data-run-time="2026-04-08 06:24 UTC">
+        <span class="qemu-leaderboard__rank">3</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/fbt1709" target="_blank" rel="noopener noreferrer">fbt1709</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="4" data-github-id="ihanzh" data-score="200" data-total-score="200" data-run-time="2026-04-08 15:38 UTC">
+        <span class="qemu-leaderboard__rank">4</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ihanzh" target="_blank" rel="noopener noreferrer">ihanzh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="5" data-github-id="nusakom" data-score="200" data-total-score="200" data-run-time="2026-04-08 21:13 UTC">
+        <span class="qemu-leaderboard__rank">5</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/nusakom" target="_blank" rel="noopener noreferrer">nusakom</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="6" data-github-id="srcres258" data-score="200" data-total-score="200" data-run-time="2026-04-10 16:38 UTC">
+        <span class="qemu-leaderboard__rank">6</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srcres258" target="_blank" rel="noopener noreferrer">srcres258</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="7" data-github-id="seehello" data-score="200" data-total-score="200" data-run-time="2026-04-11 11:28 UTC">
+        <span class="qemu-leaderboard__rank">7</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/seehello" target="_blank" rel="noopener noreferrer">seehello</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="8" data-github-id="shangguanyongshi" data-score="200" data-total-score="200" data-run-time="2026-04-15 00:45 UTC">
+        <span class="qemu-leaderboard__rank">8</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/shangguanyongshi" target="_blank" rel="noopener noreferrer">shangguanyongshi</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="9" data-github-id="flamboyante" data-score="200" data-total-score="200" data-run-time="2026-04-15 02:40 UTC">
+        <span class="qemu-leaderboard__rank">9</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flamboyante" target="_blank" rel="noopener noreferrer">flamboyante</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="10" data-github-id="LiuHongsGitHub" data-score="200" data-total-score="200" data-run-time="2026-04-16 03:42 UTC">
+        <span class="qemu-leaderboard__rank">10</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/LiuHongsGitHub" target="_blank" rel="noopener noreferrer">LiuHongsGitHub</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="11" data-github-id="Aozaki-aok0" data-score="200" data-total-score="200" data-run-time="2026-04-16 15:09 UTC">
+        <span class="qemu-leaderboard__rank">11</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Aozaki-aok0" target="_blank" rel="noopener noreferrer">Aozaki-aok0</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="12" data-github-id="clsfantasy" data-score="200" data-total-score="200" data-run-time="2026-04-17 07:52 UTC">
+        <span class="qemu-leaderboard__rank">12</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/clsfantasy" target="_blank" rel="noopener noreferrer">clsfantasy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="13" data-github-id="Sutter099" data-score="200" data-total-score="200" data-run-time="2026-04-17 10:40 UTC">
+        <span class="qemu-leaderboard__rank">13</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sutter099" target="_blank" rel="noopener noreferrer">Sutter099</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="14" data-github-id="vsvnakers" data-score="200" data-total-score="200" data-run-time="2026-04-17 19:41 UTC">
+        <span class="qemu-leaderboard__rank">14</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/vsvnakers" target="_blank" rel="noopener noreferrer">vsvnakers</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="15" data-github-id="GrexLoong" data-score="200" data-total-score="200" data-run-time="2026-04-19 15:10 UTC">
+        <span class="qemu-leaderboard__rank">15</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/GrexLoong" target="_blank" rel="noopener noreferrer">GrexLoong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="16" data-github-id="trace1729" data-score="200" data-total-score="200" data-run-time="2026-04-21 07:40 UTC">
+        <span class="qemu-leaderboard__rank">16</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/trace1729" target="_blank" rel="noopener noreferrer">trace1729</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="17" data-github-id="RainLeaf16" data-score="200" data-total-score="200" data-run-time="2026-04-25 15:08 UTC">
+        <span class="qemu-leaderboard__rank">17</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/RainLeaf16" target="_blank" rel="noopener noreferrer">RainLeaf16</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="18" data-github-id="primercoder" data-score="200" data-total-score="200" data-run-time="2026-04-27 00:27 UTC">
+        <span class="qemu-leaderboard__rank">18</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/primercoder" target="_blank" rel="noopener noreferrer">primercoder</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="19" data-github-id="littlewangzai-orz" data-score="200" data-total-score="200" data-run-time="2026-04-27 06:52 UTC">
+        <span class="qemu-leaderboard__rank">19</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/littlewangzai-orz" target="_blank" rel="noopener noreferrer">littlewangzai-orz</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="20" data-github-id="asdfgh870" data-score="200" data-total-score="200" data-run-time="2026-04-30 14:33 UTC">
+        <span class="qemu-leaderboard__rank">20</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/asdfgh870" target="_blank" rel="noopener noreferrer">asdfgh870</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="21" data-github-id="lingqian-gi" data-score="200" data-total-score="200" data-run-time="2026-05-02 12:52 UTC">
+        <span class="qemu-leaderboard__rank">21</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lingqian-gi" target="_blank" rel="noopener noreferrer">lingqian-gi</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="22" data-github-id="eternal-echo" data-score="200" data-total-score="200" data-run-time="2026-05-03 08:00 UTC">
+        <span class="qemu-leaderboard__rank">22</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eternal-echo" target="_blank" rel="noopener noreferrer">eternal-echo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="23" data-github-id="helloyuze" data-score="200" data-total-score="200" data-run-time="2026-05-07 14:52 UTC">
+        <span class="qemu-leaderboard__rank">23</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/helloyuze" target="_blank" rel="noopener noreferrer">helloyuze</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="24" data-github-id="First-da" data-score="200" data-total-score="200" data-run-time="2026-05-08 08:50 UTC">
+        <span class="qemu-leaderboard__rank">24</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/First-da" target="_blank" rel="noopener noreferrer">First-da</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="25" data-github-id="xiaoerlang0359-debug" data-score="200" data-total-score="200" data-run-time="2026-05-10 13:10 UTC">
+        <span class="qemu-leaderboard__rank">25</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiaoerlang0359-debug" target="_blank" rel="noopener noreferrer">xiaoerlang0359-debug</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="26" data-github-id="73fc" data-score="200" data-total-score="200" data-run-time="2026-05-10 14:20 UTC">
+        <span class="qemu-leaderboard__rank">26</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/73fc" target="_blank" rel="noopener noreferrer">73fc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="27" data-github-id="SSJ-ZYJ" data-score="200" data-total-score="200" data-run-time="2026-05-11 15:50 UTC">
+        <span class="qemu-leaderboard__rank">27</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/SSJ-ZYJ" target="_blank" rel="noopener noreferrer">SSJ-ZYJ</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="28" data-github-id="serf-huik" data-score="200" data-total-score="200" data-run-time="2026-05-17 09:03 UTC">
+        <span class="qemu-leaderboard__rank">28</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/serf-huik" target="_blank" rel="noopener noreferrer">serf-huik</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="29" data-github-id="GaryHu-zzz" data-score="200" data-total-score="200" data-run-time="2026-05-18 13:51 UTC">
+        <span class="qemu-leaderboard__rank">29</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/GaryHu-zzz" target="_blank" rel="noopener noreferrer">GaryHu-zzz</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="30" data-github-id="srhashdh" data-score="200" data-total-score="200" data-run-time="2026-05-20 05:42 UTC">
+        <span class="qemu-leaderboard__rank">30</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srhashdh" target="_blank" rel="noopener noreferrer">srhashdh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="31" data-github-id="2zuqisong" data-score="200" data-total-score="200" data-run-time="2026-05-25 13:55 UTC">
+        <span class="qemu-leaderboard__rank">31</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/2zuqisong" target="_blank" rel="noopener noreferrer">2zuqisong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="32" data-github-id="qinzhengxiang" data-score="200" data-total-score="200" data-run-time="2026-05-28 13:31 UTC">
+        <span class="qemu-leaderboard__rank">32</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/qinzhengxiang" target="_blank" rel="noopener noreferrer">qinzhengxiang</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="33" data-github-id="xiex386" data-score="200" data-total-score="200" data-run-time="2026-05-30 03:14 UTC">
+        <span class="qemu-leaderboard__rank">33</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiex386" target="_blank" rel="noopener noreferrer">xiex386</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="34" data-github-id="jieniguiemmm" data-score="200" data-total-score="200" data-run-time="2026-06-05 11:23 UTC">
+        <span class="qemu-leaderboard__rank">34</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jieniguiemmm" target="_blank" rel="noopener noreferrer">jieniguiemmm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="35" data-github-id="WhiteBearI" data-score="200" data-total-score="200" data-run-time="2026-06-07 23:53 UTC">
+        <span class="qemu-leaderboard__rank">35</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/WhiteBearI" target="_blank" rel="noopener noreferrer">WhiteBearI</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="36" data-github-id="yyxt-xwy" data-score="200" data-total-score="200" data-run-time="2026-06-08 13:39 UTC">
+        <span class="qemu-leaderboard__rank">36</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yyxt-xwy" target="_blank" rel="noopener noreferrer">yyxt-xwy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="37" data-github-id="Gmikele" data-score="200" data-total-score="200" data-run-time="2026-06-12 00:15 UTC">
+        <span class="qemu-leaderboard__rank">37</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Gmikele" target="_blank" rel="noopener noreferrer">Gmikele</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="38" data-github-id="endwhiteparadox" data-score="200" data-total-score="200" data-run-time="2026-06-12 09:44 UTC">
+        <span class="qemu-leaderboard__rank">38</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/endwhiteparadox" target="_blank" rel="noopener noreferrer">endwhiteparadox</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="39" data-github-id="Sunuywq" data-score="200" data-total-score="200" data-run-time="2026-06-15 13:22 UTC">
+        <span class="qemu-leaderboard__rank">39</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sunuywq" target="_blank" rel="noopener noreferrer">Sunuywq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="40" data-github-id="nv3ifu" data-score="200" data-total-score="200" data-run-time="2026-06-21 08:55 UTC">
+        <span class="qemu-leaderboard__rank">40</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/nv3ifu" target="_blank" rel="noopener noreferrer">nv3ifu</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="41" data-github-id="dweeqhd" data-score="200" data-total-score="200" data-run-time="2026-06-28 16:04 UTC">
+        <span class="qemu-leaderboard__rank">41</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dweeqhd" target="_blank" rel="noopener noreferrer">dweeqhd</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="42" data-github-id="apolecoco" data-score="200" data-total-score="200" data-run-time="2026-07-06 13:46 UTC">
+        <span class="qemu-leaderboard__rank">42</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/apolecoco" target="_blank" rel="noopener noreferrer">apolecoco</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>200</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="43" data-github-id="yunyi1201" data-score="195" data-total-score="200" data-run-time="2026-04-11 13:39 UTC">
+        <span class="qemu-leaderboard__rank">43</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunyi1201" target="_blank" rel="noopener noreferrer">yunyi1201</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="44" data-github-id="meat00" data-score="195" data-total-score="200" data-run-time="2026-04-12 09:58 UTC">
+        <span class="qemu-leaderboard__rank">44</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/meat00" target="_blank" rel="noopener noreferrer">meat00</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="45" data-github-id="LNfromNorth" data-score="195" data-total-score="200" data-run-time="2026-04-18 06:43 UTC">
+        <span class="qemu-leaderboard__rank">45</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/LNfromNorth" target="_blank" rel="noopener noreferrer">LNfromNorth</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="46" data-github-id="adgnaf" data-score="195" data-total-score="200" data-run-time="2026-04-22 08:08 UTC">
+        <span class="qemu-leaderboard__rank">46</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/adgnaf" target="_blank" rel="noopener noreferrer">adgnaf</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="47" data-github-id="yummy0406" data-score="195" data-total-score="200" data-run-time="2026-04-22 16:52 UTC">
+        <span class="qemu-leaderboard__rank">47</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yummy0406" target="_blank" rel="noopener noreferrer">yummy0406</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="48" data-github-id="BoBoDai" data-score="195" data-total-score="200" data-run-time="2026-04-25 17:40 UTC">
+        <span class="qemu-leaderboard__rank">48</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/BoBoDai" target="_blank" rel="noopener noreferrer">BoBoDai</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="49" data-github-id="Kirito-yhh" data-score="195" data-total-score="200" data-run-time="2026-04-26 15:13 UTC">
+        <span class="qemu-leaderboard__rank">49</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Kirito-yhh" target="_blank" rel="noopener noreferrer">Kirito-yhh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="50" data-github-id="Opadc" data-score="195" data-total-score="200" data-run-time="2026-05-05 14:09 UTC">
+        <span class="qemu-leaderboard__rank">50</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Opadc" target="_blank" rel="noopener noreferrer">Opadc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="51" data-github-id="EmissaryD" data-score="195" data-total-score="200" data-run-time="2026-05-08 16:01 UTC">
+        <span class="qemu-leaderboard__rank">51</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/EmissaryD" target="_blank" rel="noopener noreferrer">EmissaryD</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="52" data-github-id="gulangyuzzz" data-score="195" data-total-score="200" data-run-time="2026-05-09 15:39 UTC">
+        <span class="qemu-leaderboard__rank">52</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/gulangyuzzz" target="_blank" rel="noopener noreferrer">gulangyuzzz</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="53" data-github-id="lebenito030" data-score="195" data-total-score="200" data-run-time="2026-05-14 06:09 UTC">
+        <span class="qemu-leaderboard__rank">53</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lebenito030" target="_blank" rel="noopener noreferrer">lebenito030</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="54" data-github-id="jensenojs" data-score="195" data-total-score="200" data-run-time="2026-05-14 13:35 UTC">
+        <span class="qemu-leaderboard__rank">54</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jensenojs" target="_blank" rel="noopener noreferrer">jensenojs</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="55" data-github-id="yuanyiboyyb" data-score="195" data-total-score="200" data-run-time="2026-05-17 15:56 UTC">
+        <span class="qemu-leaderboard__rank">55</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yuanyiboyyb" target="_blank" rel="noopener noreferrer">yuanyiboyyb</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="56" data-github-id="Egg12138" data-score="195" data-total-score="200" data-run-time="2026-06-01 17:34 UTC">
+        <span class="qemu-leaderboard__rank">56</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Egg12138" target="_blank" rel="noopener noreferrer">Egg12138</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="57" data-github-id="lukamriccc" data-score="195" data-total-score="200" data-run-time="2026-06-02 10:09 UTC">
+        <span class="qemu-leaderboard__rank">57</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lukamriccc" target="_blank" rel="noopener noreferrer">lukamriccc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="58" data-github-id="after1990s" data-score="195" data-total-score="200" data-run-time="2026-06-07 13:33 UTC">
+        <span class="qemu-leaderboard__rank">58</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/after1990s" target="_blank" rel="noopener noreferrer">after1990s</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="59" data-github-id="NewFei" data-score="195" data-total-score="200" data-run-time="2026-06-13 09:25 UTC">
+        <span class="qemu-leaderboard__rank">59</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/NewFei" target="_blank" rel="noopener noreferrer">NewFei</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="60" data-github-id="yyf2050567-afk" data-score="195" data-total-score="200" data-run-time="2026-06-28 12:54 UTC">
+        <span class="qemu-leaderboard__rank">60</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yyf2050567-afk" target="_blank" rel="noopener noreferrer">yyf2050567-afk</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="61" data-github-id="Old-cpu" data-score="195" data-total-score="200" data-run-time="2026-07-06 09:08 UTC">
+        <span class="qemu-leaderboard__rank">61</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Old-cpu" target="_blank" rel="noopener noreferrer">Old-cpu</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>195</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 97.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="62" data-github-id="manbo1234" data-score="190" data-total-score="200" data-run-time="2026-04-20 12:30 UTC">
+        <span class="qemu-leaderboard__rank">62</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/manbo1234" target="_blank" rel="noopener noreferrer">manbo1234</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>190</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 95.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="63" data-github-id="ZHIKAIQ1998" data-score="190" data-total-score="200" data-run-time="2026-05-26 15:50 UTC">
+        <span class="qemu-leaderboard__rank">63</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ZHIKAIQ1998" target="_blank" rel="noopener noreferrer">ZHIKAIQ1998</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>190</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 95.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="64" data-github-id="cecho9992-boop" data-score="190" data-total-score="200" data-run-time="2026-07-03 01:43 UTC">
+        <span class="qemu-leaderboard__rank">64</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/cecho9992-boop" target="_blank" rel="noopener noreferrer">cecho9992-boop</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>190</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 95.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="65" data-github-id="destinyFvcker" data-score="180" data-total-score="200" data-run-time="2026-04-12 03:35 UTC">
+        <span class="qemu-leaderboard__rank">65</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/destinyFvcker" target="_blank" rel="noopener noreferrer">destinyFvcker</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>180</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 90.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="66" data-github-id="oscizk" data-score="180" data-total-score="200" data-run-time="2026-05-08 15:28 UTC">
+        <span class="qemu-leaderboard__rank">66</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/oscizk" target="_blank" rel="noopener noreferrer">oscizk</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>180</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 90.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="67" data-github-id="yeyumeng7799" data-score="120" data-total-score="200" data-run-time="2026-05-16 05:04 UTC">
+        <span class="qemu-leaderboard__rank">67</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yeyumeng7799" target="_blank" rel="noopener noreferrer">yeyumeng7799</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>120</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 60.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="68" data-github-id="HelloLiYifei" data-score="115" data-total-score="200" data-run-time="2026-05-12 10:06 UTC">
+        <span class="qemu-leaderboard__rank">68</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/HelloLiYifei" target="_blank" rel="noopener noreferrer">HelloLiYifei</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>115</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 57.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="69" data-github-id="chrisynl" data-score="100" data-total-score="200" data-run-time="2026-04-12 15:54 UTC">
+        <span class="qemu-leaderboard__rank">69</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/chrisynl" target="_blank" rel="noopener noreferrer">chrisynl</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 50.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="70" data-github-id="xxluestc" data-score="100" data-total-score="200" data-run-time="2026-04-16 12:01 UTC">
+        <span class="qemu-leaderboard__rank">70</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xxluestc" target="_blank" rel="noopener noreferrer">xxluestc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 50.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="71" data-github-id="xwwcyber" data-score="100" data-total-score="200" data-run-time="2026-05-10 06:04 UTC">
+        <span class="qemu-leaderboard__rank">71</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xwwcyber" target="_blank" rel="noopener noreferrer">xwwcyber</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 50.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="72" data-github-id="lemonsuqing" data-score="95" data-total-score="200" data-run-time="2026-04-15 09:12 UTC">
+        <span class="qemu-leaderboard__rank">72</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lemonsuqing" target="_blank" rel="noopener noreferrer">lemonsuqing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 47.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="73" data-github-id="ghostdragonzero" data-score="95" data-total-score="200" data-run-time="2026-04-21 09:47 UTC">
+        <span class="qemu-leaderboard__rank">73</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ghostdragonzero" target="_blank" rel="noopener noreferrer">ghostdragonzero</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 47.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="74" data-github-id="dazuo233" data-score="95" data-total-score="200" data-run-time="2026-04-23 10:00 UTC">
+        <span class="qemu-leaderboard__rank">74</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dazuo233" target="_blank" rel="noopener noreferrer">dazuo233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 47.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="75" data-github-id="Idonotno" data-score="95" data-total-score="200" data-run-time="2026-04-30 03:21 UTC">
+        <span class="qemu-leaderboard__rank">75</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Idonotno" target="_blank" rel="noopener noreferrer">Idonotno</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 47.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="76" data-github-id="firecrack" data-score="95" data-total-score="200" data-run-time="2026-07-04 15:29 UTC">
+        <span class="qemu-leaderboard__rank">76</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/firecrack" target="_blank" rel="noopener noreferrer">firecrack</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 47.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="77" data-github-id="akikaede6" data-score="90" data-total-score="200" data-run-time="2026-05-09 09:56 UTC">
+        <span class="qemu-leaderboard__rank">77</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/akikaede6" target="_blank" rel="noopener noreferrer">akikaede6</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>90</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 45.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="78" data-github-id="yzqyzqyzq-git" data-score="90" data-total-score="200" data-run-time="2026-05-16 10:13 UTC">
+        <span class="qemu-leaderboard__rank">78</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yzqyzqyzq-git" target="_blank" rel="noopener noreferrer">yzqyzqyzq-git</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>90</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 45.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="79" data-github-id="csdjr" data-score="90" data-total-score="200" data-run-time="2026-05-29 16:34 UTC">
+        <span class="qemu-leaderboard__rank">79</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csdjr" target="_blank" rel="noopener noreferrer">csdjr</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>90</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 45.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="80" data-github-id="zhenbaii" data-score="85" data-total-score="200" data-run-time="2026-04-09 09:54 UTC">
+        <span class="qemu-leaderboard__rank">80</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zhenbaii" target="_blank" rel="noopener noreferrer">zhenbaii</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>85</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 42.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="81" data-github-id="RubMaker" data-score="85" data-total-score="200" data-run-time="2026-04-10 09:37 UTC">
+        <span class="qemu-leaderboard__rank">81</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/RubMaker" target="_blank" rel="noopener noreferrer">RubMaker</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>85</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 42.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="82" data-github-id="luis-233" data-score="80" data-total-score="200" data-run-time="2026-04-14 08:53 UTC">
+        <span class="qemu-leaderboard__rank">82</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/luis-233" target="_blank" rel="noopener noreferrer">luis-233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>80</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 40.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="83" data-github-id="Hokfs" data-score="80" data-total-score="200" data-run-time="2026-04-28 07:31 UTC">
+        <span class="qemu-leaderboard__rank">83</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Hokfs" target="_blank" rel="noopener noreferrer">Hokfs</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>80</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 40.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="84" data-github-id="0ranan" data-score="80" data-total-score="200" data-run-time="2026-05-02 09:37 UTC">
+        <span class="qemu-leaderboard__rank">84</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/0ranan" target="_blank" rel="noopener noreferrer">0ranan</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>80</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 40.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="85" data-github-id="h1y2g3l4y5" data-score="70" data-total-score="200" data-run-time="2026-04-17 16:27 UTC">
+        <span class="qemu-leaderboard__rank">85</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/h1y2g3l4y5" target="_blank" rel="noopener noreferrer">h1y2g3l4y5</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>70</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 35.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="86" data-github-id="KeyBor" data-score="60" data-total-score="200" data-run-time="2026-04-06 14:34 UTC">
+        <span class="qemu-leaderboard__rank">86</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/KeyBor" target="_blank" rel="noopener noreferrer">KeyBor</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>60</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 30.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="87" data-github-id="yunjianshijie" data-score="60" data-total-score="200" data-run-time="2026-04-26 09:55 UTC">
+        <span class="qemu-leaderboard__rank">87</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunjianshijie" target="_blank" rel="noopener noreferrer">yunjianshijie</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>60</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 30.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="88" data-github-id="55Curry" data-score="55" data-total-score="200" data-run-time="2026-04-22 13:00 UTC">
+        <span class="qemu-leaderboard__rank">88</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/55Curry" target="_blank" rel="noopener noreferrer">55Curry</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>55</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 27.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="89" data-github-id="SiYue-ZO" data-score="50" data-total-score="200" data-run-time="2026-04-26 13:41 UTC">
+        <span class="qemu-leaderboard__rank">89</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/SiYue-ZO" target="_blank" rel="noopener noreferrer">SiYue-ZO</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>50</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 25.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="90" data-github-id="AtomAlpaca" data-score="50" data-total-score="200" data-run-time="2026-06-17 10:42 UTC">
+        <span class="qemu-leaderboard__rank">90</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/AtomAlpaca" target="_blank" rel="noopener noreferrer">AtomAlpaca</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>50</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 25.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="91" data-github-id="zhu30844" data-score="45" data-total-score="200" data-run-time="2026-04-07 06:10 UTC">
+        <span class="qemu-leaderboard__rank">91</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zhu30844" target="_blank" rel="noopener noreferrer">zhu30844</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>45</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 22.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="92" data-github-id="Beatrice0377" data-score="40" data-total-score="200" data-run-time="2026-04-16 10:41 UTC">
+        <span class="qemu-leaderboard__rank">92</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Beatrice0377" target="_blank" rel="noopener noreferrer">Beatrice0377</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>40</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 20.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="93" data-github-id="enlist12" data-score="35" data-total-score="200" data-run-time="2026-04-09 06:27 UTC">
+        <span class="qemu-leaderboard__rank">93</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/enlist12" target="_blank" rel="noopener noreferrer">enlist12</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>35</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 17.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="94" data-github-id="huclimb" data-score="35" data-total-score="200" data-run-time="2026-05-10 15:25 UTC">
+        <span class="qemu-leaderboard__rank">94</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/huclimb" target="_blank" rel="noopener noreferrer">huclimb</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>35</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 17.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="95" data-github-id="SinnLiu" data-score="35" data-total-score="200" data-run-time="2026-05-17 14:49 UTC">
+        <span class="qemu-leaderboard__rank">95</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/SinnLiu" target="_blank" rel="noopener noreferrer">SinnLiu</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>35</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 17.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="96" data-github-id="keepgoong" data-score="30" data-total-score="200" data-run-time="2026-06-23 14:42 UTC">
+        <span class="qemu-leaderboard__rank">96</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/keepgoong" target="_blank" rel="noopener noreferrer">keepgoong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>30</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 15.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="97" data-github-id="Lcollection" data-score="25" data-total-score="200" data-run-time="2026-04-19 22:08 UTC">
+        <span class="qemu-leaderboard__rank">97</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Lcollection" target="_blank" rel="noopener noreferrer">Lcollection</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>25</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 12.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="98" data-github-id="Sleepless9" data-score="25" data-total-score="200" data-run-time="2026-04-23 09:26 UTC">
+        <span class="qemu-leaderboard__rank">98</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sleepless9" target="_blank" rel="noopener noreferrer">Sleepless9</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>25</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 12.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="99" data-github-id="ZT0717" data-score="20" data-total-score="200" data-run-time="2026-04-17 12:10 UTC">
+        <span class="qemu-leaderboard__rank">99</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ZT0717" target="_blank" rel="noopener noreferrer">ZT0717</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>20</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="100" data-github-id="GreyFoox" data-score="20" data-total-score="200" data-run-time="2026-04-30 06:47 UTC">
+        <span class="qemu-leaderboard__rank">100</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/GreyFoox" target="_blank" rel="noopener noreferrer">GreyFoox</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>20</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="101" data-github-id="chennuo927" data-score="20" data-total-score="200" data-run-time="2026-05-10 07:18 UTC">
+        <span class="qemu-leaderboard__rank">101</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/chennuo927" target="_blank" rel="noopener noreferrer">chennuo927</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>20</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="102" data-github-id="ZhonghuaQi" data-score="15" data-total-score="200" data-run-time="2026-06-05 10:19 UTC">
+        <span class="qemu-leaderboard__rank">102</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ZhonghuaQi" target="_blank" rel="noopener noreferrer">ZhonghuaQi</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>15</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 7.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="103" data-github-id="ye-rm" data-score="10" data-total-score="200" data-run-time="2026-04-06 13:37 UTC">
+        <span class="qemu-leaderboard__rank">103</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ye-rm" target="_blank" rel="noopener noreferrer">ye-rm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="104" data-github-id="WCMS688" data-score="10" data-total-score="200" data-run-time="2026-04-16 11:19 UTC">
+        <span class="qemu-leaderboard__rank">104</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/WCMS688" target="_blank" rel="noopener noreferrer">WCMS688</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="105" data-github-id="DiQing2007" data-score="10" data-total-score="200" data-run-time="2026-04-20 17:12 UTC">
+        <span class="qemu-leaderboard__rank">105</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/DiQing2007" target="_blank" rel="noopener noreferrer">DiQing2007</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="106" data-github-id="xiaozhuABCD1234" data-score="10" data-total-score="200" data-run-time="2026-05-18 03:04 UTC">
+        <span class="qemu-leaderboard__rank">106</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiaozhuABCD1234" target="_blank" rel="noopener noreferrer">xiaozhuABCD1234</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="107" data-github-id="bbbbbq" data-score="5" data-total-score="200" data-run-time="2026-04-08 16:40 UTC">
+        <span class="qemu-leaderboard__rank">107</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/bbbbbq" target="_blank" rel="noopener noreferrer">bbbbbq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="108" data-github-id="heichiii" data-score="5" data-total-score="200" data-run-time="2026-04-12 21:10 UTC">
+        <span class="qemu-leaderboard__rank">108</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/heichiii" target="_blank" rel="noopener noreferrer">heichiii</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="109" data-github-id="ctdrm" data-score="5" data-total-score="200" data-run-time="2026-04-13 10:36 UTC">
+        <span class="qemu-leaderboard__rank">109</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ctdrm" target="_blank" rel="noopener noreferrer">ctdrm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="110" data-github-id="Eclipse-Arrebol" data-score="5" data-total-score="200" data-run-time="2026-04-13 13:42 UTC">
+        <span class="qemu-leaderboard__rank">110</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Eclipse-Arrebol" target="_blank" rel="noopener noreferrer">Eclipse-Arrebol</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="111" data-github-id="Eclipse-yanluo" data-score="5" data-total-score="200" data-run-time="2026-04-14 03:51 UTC">
+        <span class="qemu-leaderboard__rank">111</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Eclipse-yanluo" target="_blank" rel="noopener noreferrer">Eclipse-yanluo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="112" data-github-id="duckchih" data-score="5" data-total-score="200" data-run-time="2026-04-26 13:38 UTC">
+        <span class="qemu-leaderboard__rank">112</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/duckchih" target="_blank" rel="noopener noreferrer">duckchih</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="113" data-github-id="lusixing" data-score="5" data-total-score="200" data-run-time="2026-04-27 07:55 UTC">
+        <span class="qemu-leaderboard__rank">113</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lusixing" target="_blank" rel="noopener noreferrer">lusixing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="114" data-github-id="weypro" data-score="5" data-total-score="200" data-run-time="2026-05-01 15:28 UTC">
+        <span class="qemu-leaderboard__rank">114</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/weypro" target="_blank" rel="noopener noreferrer">weypro</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="115" data-github-id="zhang-san-007" data-score="5" data-total-score="200" data-run-time="2026-05-08 15:18 UTC">
+        <span class="qemu-leaderboard__rank">115</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zhang-san-007" target="_blank" rel="noopener noreferrer">zhang-san-007</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 2.50%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="116" data-github-id="aaaaqweaaaa" data-score="0" data-total-score="200" data-run-time="2026-04-24 10:56 UTC">
+        <span class="qemu-leaderboard__rank">116</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/aaaaqweaaaa" target="_blank" rel="noopener noreferrer">aaaaqweaaaa</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>0</strong><small>/200</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 0.00%"></span></span>
+        </span>
+      </li>
+    </ol>
+  </div>
+</section>

--- a/docs/leaderboards/2026/basic/rust.md
+++ b/docs/leaderboards/2026/basic/rust.md
@@ -1,62 +1,471 @@
 # QEMU 训练营 2026 基础阶段 Rust 排行榜
 
-[C 语言](c.md) | [**Rust**](rust.md)
+<nav class="qemu-leaderboard-tabs" aria-label="排行榜切换">
+  <a class="qemu-leaderboard-tabs__item" href="c.md">C 语言</a>
+  <a class="qemu-leaderboard-tabs__item is-active" href="rust.md" aria-current="page">Rust</a>
+</nav>
 
-| 排名 | GitHub ID | 得分 | 总分 | 评分 run 时间 |
-| --- | --- | ---: | ---: | --- |
-| 1 | silicalet | 95 | 95 | 2026-04-06 18:49 UTC |
-| 2 | srcres258 | 95 | 95 | 2026-04-07 03:07 UTC |
-| 3 | anicbeer | 95 | 95 | 2026-04-07 12:10 UTC |
-| 4 | nusakom | 95 | 95 | 2026-04-08 18:56 UTC |
-| 5 | lickoc | 95 | 95 | 2026-04-09 01:31 UTC |
-| 6 | Plucky923 | 95 | 95 | 2026-04-09 02:42 UTC |
-| 7 | Smart-SangGe | 95 | 95 | 2026-04-09 11:13 UTC |
-| 8 | destinyFvcker | 95 | 95 | 2026-04-11 18:33 UTC |
-| 9 | SlieNce810 | 95 | 95 | 2026-04-12 09:58 UTC |
-| 10 | csmyx | 95 | 95 | 2026-04-12 18:56 UTC |
-| 11 | Kcang-gna | 95 | 95 | 2026-04-14 05:36 UTC |
-| 12 | refr66 | 95 | 95 | 2026-04-14 10:32 UTC |
-| 13 | CFHaini | 95 | 95 | 2026-04-15 11:00 UTC |
-| 14 | coldriver-chen | 95 | 95 | 2026-04-16 03:57 UTC |
-| 15 | LNfromNorth | 95 | 95 | 2026-04-18 07:16 UTC |
-| 16 | mympeg | 95 | 95 | 2026-04-18 09:11 UTC |
-| 17 | fgh1999 | 95 | 95 | 2026-04-19 08:59 UTC |
-| 18 | caiwen666 | 95 | 95 | 2026-04-20 07:20 UTC |
-| 19 | Raczyx | 95 | 95 | 2026-04-21 14:19 UTC |
-| 20 | LYR-liyanrong | 95 | 95 | 2026-04-21 15:28 UTC |
-| 21 | cn-sys | 95 | 95 | 2026-04-22 10:35 UTC |
-| 22 | Takumi-wake | 95 | 95 | 2026-04-24 15:01 UTC |
-| 23 | playerInEminor | 95 | 95 | 2026-04-25 17:39 UTC |
-| 24 | flespark | 95 | 95 | 2026-04-26 02:14 UTC |
-| 25 | BoBoDai | 95 | 95 | 2026-04-26 06:47 UTC |
-| 26 | trace1729 | 95 | 95 | 2026-04-27 09:35 UTC |
-| 27 | PingGuoMiaoMiao | 95 | 95 | 2026-04-30 12:21 UTC |
-| 28 | jlff | 95 | 95 | 2026-05-02 02:58 UTC |
-| 29 | Promin3 | 95 | 95 | 2026-05-04 09:57 UTC |
-| 30 | msuadOf | 95 | 95 | 2026-05-05 14:47 UTC |
-| 31 | zyk632 | 95 | 95 | 2026-05-05 16:08 UTC |
-| 32 | PassingThroughStarDust | 95 | 95 | 2026-05-05 17:14 UTC |
-| 33 | ghostdragonzero | 95 | 95 | 2026-05-06 10:24 UTC |
-| 34 | eyauwag | 95 | 95 | 2026-05-07 09:15 UTC |
-| 35 | ye-rm | 95 | 95 | 2026-05-09 08:46 UTC |
-| 36 | lsynpy | 95 | 95 | 2026-05-11 09:26 UTC |
-| 37 | yastiqus | 95 | 95 | 2026-05-12 20:44 UTC |
-| 38 | rhbfc | 95 | 95 | 2026-05-14 10:04 UTC |
-| 39 | yuanyiboyyb | 95 | 95 | 2026-05-17 05:15 UTC |
-| 40 | lebenito030 | 95 | 95 | 2026-05-18 08:23 UTC |
-| 41 | OutisNyel | 95 | 95 | 2026-05-23 12:39 UTC |
-| 42 | srhashdh | 95 | 95 | 2026-05-25 05:45 UTC |
-| 43 | assassinlex | 95 | 95 | 2026-05-27 10:50 UTC |
-| 44 | scrail | 94 | 95 | 2026-04-09 16:52 UTC |
-| 45 | manbo1234 | 94 | 95 | 2026-04-28 08:46 UTC |
-| 46 | IiCEight | 94 | 95 | 2026-06-08 07:12 UTC |
-| 47 | Egg12138 | 94 | 95 | 2026-06-20 05:12 UTC |
-| 48 | Vn1c0rn | 94 | 95 | 2026-06-23 08:30 UTC |
-| 49 | l825l | 94 | 95 | 2026-06-29 17:54 UTC |
-| 50 | ovwxxwvo | 94 | 95 | 2026-07-04 05:45 UTC |
-| 51 | AtomAlpaca | 50 | 95 | 2026-06-23 12:20 UTC |
-| 52 | xyjl-ly | 36 | 95 | 2026-04-29 17:43 UTC |
-| 53 | xxluestc | 33 | 95 | 2026-04-08 12:24 UTC |
-| 54 | benx-guo | 1 | 95 | 2026-04-08 10:47 UTC |
-
-每天刷新一次｜快照生成时间：2026-07-08 20:50 UTC
+<section class="qemu-leaderboard" aria-label="排行榜">
+  <div class="qemu-leaderboard__header">
+    <div>
+      <div class="qemu-leaderboard__title">基础阶段 · Rust</div>
+      <div class="qemu-leaderboard__subtitle">每天刷新一次</div>
+    </div>
+    <div class="qemu-leaderboard__updated">快照生成时间：2026-07-09 14:39 UTC</div>
+  </div>
+  <div class="qemu-leaderboard__metrics">
+    <div class="qemu-leaderboard__metric qemu-leaderboard__metric--primary">
+      <span class="qemu-leaderboard__metric-value">54</span>
+      <span class="qemu-leaderboard__metric-label">上榜人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">43</span>
+      <span class="qemu-leaderboard__metric-label">满分人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">95/95</span>
+      <span class="qemu-leaderboard__metric-label">最高得分</span>
+    </div>
+  </div>
+  <div class="qemu-leaderboard__scroll">
+    <div class="qemu-leaderboard__list-head" aria-hidden="true">
+      <span>排名</span>
+      <span>GitHub ID</span>
+      <span>得分</span>
+    </div>
+    <ol class="qemu-leaderboard__rows">
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="1" data-github-id="silicalet" data-score="95" data-total-score="95" data-run-time="2026-04-06 18:49 UTC">
+        <span class="qemu-leaderboard__rank">1</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/silicalet" target="_blank" rel="noopener noreferrer">silicalet</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="2" data-github-id="srcres258" data-score="95" data-total-score="95" data-run-time="2026-04-07 03:07 UTC">
+        <span class="qemu-leaderboard__rank">2</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srcres258" target="_blank" rel="noopener noreferrer">srcres258</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="3" data-github-id="anicbeer" data-score="95" data-total-score="95" data-run-time="2026-04-07 12:10 UTC">
+        <span class="qemu-leaderboard__rank">3</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/anicbeer" target="_blank" rel="noopener noreferrer">anicbeer</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="4" data-github-id="nusakom" data-score="95" data-total-score="95" data-run-time="2026-04-08 18:56 UTC">
+        <span class="qemu-leaderboard__rank">4</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/nusakom" target="_blank" rel="noopener noreferrer">nusakom</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="5" data-github-id="lickoc" data-score="95" data-total-score="95" data-run-time="2026-04-09 01:31 UTC">
+        <span class="qemu-leaderboard__rank">5</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lickoc" target="_blank" rel="noopener noreferrer">lickoc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="6" data-github-id="Plucky923" data-score="95" data-total-score="95" data-run-time="2026-04-09 02:42 UTC">
+        <span class="qemu-leaderboard__rank">6</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Plucky923" target="_blank" rel="noopener noreferrer">Plucky923</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="7" data-github-id="Smart-SangGe" data-score="95" data-total-score="95" data-run-time="2026-04-09 11:13 UTC">
+        <span class="qemu-leaderboard__rank">7</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Smart-SangGe" target="_blank" rel="noopener noreferrer">Smart-SangGe</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="8" data-github-id="destinyFvcker" data-score="95" data-total-score="95" data-run-time="2026-04-11 18:33 UTC">
+        <span class="qemu-leaderboard__rank">8</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/destinyFvcker" target="_blank" rel="noopener noreferrer">destinyFvcker</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="9" data-github-id="SlieNce810" data-score="95" data-total-score="95" data-run-time="2026-04-12 09:58 UTC">
+        <span class="qemu-leaderboard__rank">9</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/SlieNce810" target="_blank" rel="noopener noreferrer">SlieNce810</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="10" data-github-id="csmyx" data-score="95" data-total-score="95" data-run-time="2026-04-12 18:56 UTC">
+        <span class="qemu-leaderboard__rank">10</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csmyx" target="_blank" rel="noopener noreferrer">csmyx</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="11" data-github-id="Kcang-gna" data-score="95" data-total-score="95" data-run-time="2026-04-14 05:36 UTC">
+        <span class="qemu-leaderboard__rank">11</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Kcang-gna" target="_blank" rel="noopener noreferrer">Kcang-gna</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="12" data-github-id="refr66" data-score="95" data-total-score="95" data-run-time="2026-04-14 10:32 UTC">
+        <span class="qemu-leaderboard__rank">12</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/refr66" target="_blank" rel="noopener noreferrer">refr66</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="13" data-github-id="CFHaini" data-score="95" data-total-score="95" data-run-time="2026-04-15 11:00 UTC">
+        <span class="qemu-leaderboard__rank">13</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/CFHaini" target="_blank" rel="noopener noreferrer">CFHaini</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="14" data-github-id="coldriver-chen" data-score="95" data-total-score="95" data-run-time="2026-04-16 03:57 UTC">
+        <span class="qemu-leaderboard__rank">14</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/coldriver-chen" target="_blank" rel="noopener noreferrer">coldriver-chen</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="15" data-github-id="LNfromNorth" data-score="95" data-total-score="95" data-run-time="2026-04-18 07:16 UTC">
+        <span class="qemu-leaderboard__rank">15</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/LNfromNorth" target="_blank" rel="noopener noreferrer">LNfromNorth</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="16" data-github-id="mympeg" data-score="95" data-total-score="95" data-run-time="2026-04-18 09:11 UTC">
+        <span class="qemu-leaderboard__rank">16</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/mympeg" target="_blank" rel="noopener noreferrer">mympeg</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="17" data-github-id="fgh1999" data-score="95" data-total-score="95" data-run-time="2026-04-19 08:59 UTC">
+        <span class="qemu-leaderboard__rank">17</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/fgh1999" target="_blank" rel="noopener noreferrer">fgh1999</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="18" data-github-id="caiwen666" data-score="95" data-total-score="95" data-run-time="2026-04-20 07:20 UTC">
+        <span class="qemu-leaderboard__rank">18</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/caiwen666" target="_blank" rel="noopener noreferrer">caiwen666</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="19" data-github-id="Raczyx" data-score="95" data-total-score="95" data-run-time="2026-04-21 14:19 UTC">
+        <span class="qemu-leaderboard__rank">19</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Raczyx" target="_blank" rel="noopener noreferrer">Raczyx</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="20" data-github-id="LYR-liyanrong" data-score="95" data-total-score="95" data-run-time="2026-04-21 15:28 UTC">
+        <span class="qemu-leaderboard__rank">20</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/LYR-liyanrong" target="_blank" rel="noopener noreferrer">LYR-liyanrong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="21" data-github-id="cn-sys" data-score="95" data-total-score="95" data-run-time="2026-04-22 10:35 UTC">
+        <span class="qemu-leaderboard__rank">21</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/cn-sys" target="_blank" rel="noopener noreferrer">cn-sys</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="22" data-github-id="Takumi-wake" data-score="95" data-total-score="95" data-run-time="2026-04-24 15:01 UTC">
+        <span class="qemu-leaderboard__rank">22</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Takumi-wake" target="_blank" rel="noopener noreferrer">Takumi-wake</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="23" data-github-id="playerInEminor" data-score="95" data-total-score="95" data-run-time="2026-04-25 17:39 UTC">
+        <span class="qemu-leaderboard__rank">23</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/playerInEminor" target="_blank" rel="noopener noreferrer">playerInEminor</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="24" data-github-id="flespark" data-score="95" data-total-score="95" data-run-time="2026-04-26 02:14 UTC">
+        <span class="qemu-leaderboard__rank">24</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flespark" target="_blank" rel="noopener noreferrer">flespark</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="25" data-github-id="BoBoDai" data-score="95" data-total-score="95" data-run-time="2026-04-26 06:47 UTC">
+        <span class="qemu-leaderboard__rank">25</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/BoBoDai" target="_blank" rel="noopener noreferrer">BoBoDai</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="26" data-github-id="trace1729" data-score="95" data-total-score="95" data-run-time="2026-04-27 09:35 UTC">
+        <span class="qemu-leaderboard__rank">26</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/trace1729" target="_blank" rel="noopener noreferrer">trace1729</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="27" data-github-id="PingGuoMiaoMiao" data-score="95" data-total-score="95" data-run-time="2026-04-30 12:21 UTC">
+        <span class="qemu-leaderboard__rank">27</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/PingGuoMiaoMiao" target="_blank" rel="noopener noreferrer">PingGuoMiaoMiao</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="28" data-github-id="jlff" data-score="95" data-total-score="95" data-run-time="2026-05-02 02:58 UTC">
+        <span class="qemu-leaderboard__rank">28</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jlff" target="_blank" rel="noopener noreferrer">jlff</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="29" data-github-id="Promin3" data-score="95" data-total-score="95" data-run-time="2026-05-04 09:57 UTC">
+        <span class="qemu-leaderboard__rank">29</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Promin3" target="_blank" rel="noopener noreferrer">Promin3</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="30" data-github-id="msuadOf" data-score="95" data-total-score="95" data-run-time="2026-05-05 14:47 UTC">
+        <span class="qemu-leaderboard__rank">30</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/msuadOf" target="_blank" rel="noopener noreferrer">msuadOf</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="31" data-github-id="zyk632" data-score="95" data-total-score="95" data-run-time="2026-05-05 16:08 UTC">
+        <span class="qemu-leaderboard__rank">31</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zyk632" target="_blank" rel="noopener noreferrer">zyk632</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="32" data-github-id="PassingThroughStarDust" data-score="95" data-total-score="95" data-run-time="2026-05-05 17:14 UTC">
+        <span class="qemu-leaderboard__rank">32</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/PassingThroughStarDust" target="_blank" rel="noopener noreferrer">PassingThroughStarDust</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="33" data-github-id="ghostdragonzero" data-score="95" data-total-score="95" data-run-time="2026-05-06 10:24 UTC">
+        <span class="qemu-leaderboard__rank">33</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ghostdragonzero" target="_blank" rel="noopener noreferrer">ghostdragonzero</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="34" data-github-id="eyauwag" data-score="95" data-total-score="95" data-run-time="2026-05-07 09:15 UTC">
+        <span class="qemu-leaderboard__rank">34</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eyauwag" target="_blank" rel="noopener noreferrer">eyauwag</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="35" data-github-id="ye-rm" data-score="95" data-total-score="95" data-run-time="2026-05-09 08:46 UTC">
+        <span class="qemu-leaderboard__rank">35</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ye-rm" target="_blank" rel="noopener noreferrer">ye-rm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="36" data-github-id="lsynpy" data-score="95" data-total-score="95" data-run-time="2026-05-11 09:26 UTC">
+        <span class="qemu-leaderboard__rank">36</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lsynpy" target="_blank" rel="noopener noreferrer">lsynpy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="37" data-github-id="yastiqus" data-score="95" data-total-score="95" data-run-time="2026-05-12 20:44 UTC">
+        <span class="qemu-leaderboard__rank">37</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yastiqus" target="_blank" rel="noopener noreferrer">yastiqus</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="38" data-github-id="rhbfc" data-score="95" data-total-score="95" data-run-time="2026-05-14 10:04 UTC">
+        <span class="qemu-leaderboard__rank">38</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/rhbfc" target="_blank" rel="noopener noreferrer">rhbfc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="39" data-github-id="yuanyiboyyb" data-score="95" data-total-score="95" data-run-time="2026-05-17 05:15 UTC">
+        <span class="qemu-leaderboard__rank">39</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yuanyiboyyb" target="_blank" rel="noopener noreferrer">yuanyiboyyb</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="40" data-github-id="lebenito030" data-score="95" data-total-score="95" data-run-time="2026-05-18 08:23 UTC">
+        <span class="qemu-leaderboard__rank">40</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lebenito030" target="_blank" rel="noopener noreferrer">lebenito030</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="41" data-github-id="OutisNyel" data-score="95" data-total-score="95" data-run-time="2026-05-23 12:39 UTC">
+        <span class="qemu-leaderboard__rank">41</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/OutisNyel" target="_blank" rel="noopener noreferrer">OutisNyel</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="42" data-github-id="srhashdh" data-score="95" data-total-score="95" data-run-time="2026-05-25 05:45 UTC">
+        <span class="qemu-leaderboard__rank">42</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srhashdh" target="_blank" rel="noopener noreferrer">srhashdh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="43" data-github-id="assassinlex" data-score="95" data-total-score="95" data-run-time="2026-05-27 10:50 UTC">
+        <span class="qemu-leaderboard__rank">43</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/assassinlex" target="_blank" rel="noopener noreferrer">assassinlex</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>95</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="44" data-github-id="scrail" data-score="94" data-total-score="95" data-run-time="2026-04-09 16:52 UTC">
+        <span class="qemu-leaderboard__rank">44</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/scrail" target="_blank" rel="noopener noreferrer">scrail</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>94</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 98.95%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="45" data-github-id="manbo1234" data-score="94" data-total-score="95" data-run-time="2026-04-28 08:46 UTC">
+        <span class="qemu-leaderboard__rank">45</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/manbo1234" target="_blank" rel="noopener noreferrer">manbo1234</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>94</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 98.95%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="46" data-github-id="IiCEight" data-score="94" data-total-score="95" data-run-time="2026-06-08 07:12 UTC">
+        <span class="qemu-leaderboard__rank">46</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/IiCEight" target="_blank" rel="noopener noreferrer">IiCEight</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>94</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 98.95%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="47" data-github-id="Egg12138" data-score="94" data-total-score="95" data-run-time="2026-06-20 05:12 UTC">
+        <span class="qemu-leaderboard__rank">47</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Egg12138" target="_blank" rel="noopener noreferrer">Egg12138</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>94</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 98.95%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="48" data-github-id="Vn1c0rn" data-score="94" data-total-score="95" data-run-time="2026-06-23 08:30 UTC">
+        <span class="qemu-leaderboard__rank">48</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Vn1c0rn" target="_blank" rel="noopener noreferrer">Vn1c0rn</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>94</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 98.95%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="49" data-github-id="l825l" data-score="94" data-total-score="95" data-run-time="2026-06-29 17:54 UTC">
+        <span class="qemu-leaderboard__rank">49</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/l825l" target="_blank" rel="noopener noreferrer">l825l</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>94</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 98.95%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="50" data-github-id="ovwxxwvo" data-score="94" data-total-score="95" data-run-time="2026-07-04 05:45 UTC">
+        <span class="qemu-leaderboard__rank">50</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ovwxxwvo" target="_blank" rel="noopener noreferrer">ovwxxwvo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>94</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 98.95%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="51" data-github-id="AtomAlpaca" data-score="50" data-total-score="95" data-run-time="2026-06-23 12:20 UTC">
+        <span class="qemu-leaderboard__rank">51</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/AtomAlpaca" target="_blank" rel="noopener noreferrer">AtomAlpaca</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>50</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 52.63%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="52" data-github-id="xyjl-ly" data-score="36" data-total-score="95" data-run-time="2026-04-29 17:43 UTC">
+        <span class="qemu-leaderboard__rank">52</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xyjl-ly" target="_blank" rel="noopener noreferrer">xyjl-ly</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>36</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 37.89%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="53" data-github-id="xxluestc" data-score="33" data-total-score="95" data-run-time="2026-04-08 12:24 UTC">
+        <span class="qemu-leaderboard__rank">53</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xxluestc" target="_blank" rel="noopener noreferrer">xxluestc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>33</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 34.74%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="54" data-github-id="benx-guo" data-score="1" data-total-score="95" data-run-time="2026-04-08 10:47 UTC">
+        <span class="qemu-leaderboard__rank">54</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/benx-guo" target="_blank" rel="noopener noreferrer">benx-guo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>1</strong><small>/95</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 1.05%"></span></span>
+        </span>
+      </li>
+    </ol>
+  </div>
+</section>

--- a/docs/leaderboards/2026/professional/cpu.md
+++ b/docs/leaderboards/2026/professional/cpu.md
@@ -1,43 +1,321 @@
 # QEMU 训练营 2026 专业阶段 CPU 方向排行榜
 
-[**CPU 方向**](cpu.md) | [SoC 方向](soc.md) | [GPGPU 方向](gpgpu.md) | [Rust 方向](rust.md)
+<nav class="qemu-leaderboard-tabs" aria-label="排行榜切换">
+  <a class="qemu-leaderboard-tabs__item is-active" href="cpu.md" aria-current="page">CPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="soc.md">SoC 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="gpgpu.md">GPGPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="rust.md">Rust 方向</a>
+</nav>
 
-| 排名 | GitHub ID | 得分 | 总分 | 评分 run 时间 |
-| --- | --- | ---: | ---: | --- |
-| 1 | fbt1709 | 100 | 100 | 2026-04-13 10:35 UTC |
-| 2 | Lfan-ke | 100 | 100 | 2026-04-15 00:55 UTC |
-| 3 | Plucky923 | 100 | 100 | 2026-04-17 05:55 UTC |
-| 4 | Dirinkbottle | 100 | 100 | 2026-04-17 11:00 UTC |
-| 5 | clsfantasy | 100 | 100 | 2026-04-18 09:39 UTC |
-| 6 | csmyx | 100 | 100 | 2026-04-18 15:58 UTC |
-| 7 | coldriver-chen | 100 | 100 | 2026-04-20 04:19 UTC |
-| 8 | h1y2g3l4y5 | 100 | 100 | 2026-04-21 15:57 UTC |
-| 9 | anicbeer | 100 | 100 | 2026-04-22 13:55 UTC |
-| 10 | srcres258 | 100 | 100 | 2026-04-24 03:17 UTC |
-| 11 | KeyBor | 100 | 100 | 2026-04-28 05:52 UTC |
-| 12 | adgnaf | 100 | 100 | 2026-04-28 07:09 UTC |
-| 13 | PingGuoMiaoMiao | 100 | 100 | 2026-05-02 16:42 UTC |
-| 14 | lusixing | 100 | 100 | 2026-05-04 09:14 UTC |
-| 15 | Sutter099 | 100 | 100 | 2026-05-07 14:54 UTC |
-| 16 | skinterqwe | 100 | 100 | 2026-05-08 01:14 UTC |
-| 17 | scrail | 100 | 100 | 2026-05-13 08:10 UTC |
-| 18 | silicalet | 100 | 100 | 2026-05-14 12:14 UTC |
-| 19 | trace1729 | 100 | 100 | 2026-05-20 06:54 UTC |
-| 20 | vsvnakers | 100 | 100 | 2026-05-23 15:56 UTC |
-| 21 | bbbbbq | 100 | 100 | 2026-05-23 16:58 UTC |
-| 22 | enlist12 | 100 | 100 | 2026-05-26 04:20 UTC |
-| 23 | yuanyiboyyb | 100 | 100 | 2026-05-27 12:35 UTC |
-| 24 | Eclipse-Arrebol | 100 | 100 | 2026-05-30 12:59 UTC |
-| 25 | flespark | 100 | 100 | 2026-06-02 10:28 UTC |
-| 26 | 2zuqisong | 100 | 100 | 2026-06-05 07:16 UTC |
-| 27 | srhashdh | 100 | 100 | 2026-06-05 09:16 UTC |
-| 28 | random25160765-collab | 100 | 100 | 2026-06-15 15:10 UTC |
-| 29 | First-da | 100 | 100 | 2026-06-21 05:26 UTC |
-| 30 | asdfgh870 | 100 | 100 | 2026-06-21 14:04 UTC |
-| 31 | WhiteBearI | 100 | 100 | 2026-06-23 13:38 UTC |
-| 32 | Aozaki-aok0 | 100 | 100 | 2026-07-08 07:50 UTC |
-| 33 | Opadc | 60 | 100 | 2026-05-27 13:58 UTC |
-| 34 | mhubing | 50 | 100 | 2026-04-27 01:56 UTC |
-| 35 | litianxing2016 | 10 | 100 | 2026-07-02 09:36 UTC |
-
-每天刷新一次｜快照生成时间：2026-07-08 20:50 UTC
+<section class="qemu-leaderboard" aria-label="排行榜">
+  <div class="qemu-leaderboard__header">
+    <div>
+      <div class="qemu-leaderboard__title">专业阶段 · CPU 方向</div>
+      <div class="qemu-leaderboard__subtitle">每天刷新一次</div>
+    </div>
+    <div class="qemu-leaderboard__updated">快照生成时间：2026-07-09 14:39 UTC</div>
+  </div>
+  <div class="qemu-leaderboard__metrics">
+    <div class="qemu-leaderboard__metric qemu-leaderboard__metric--primary">
+      <span class="qemu-leaderboard__metric-value">35</span>
+      <span class="qemu-leaderboard__metric-label">上榜人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">32</span>
+      <span class="qemu-leaderboard__metric-label">满分人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">100/100</span>
+      <span class="qemu-leaderboard__metric-label">最高得分</span>
+    </div>
+  </div>
+  <div class="qemu-leaderboard__scroll">
+    <div class="qemu-leaderboard__list-head" aria-hidden="true">
+      <span>排名</span>
+      <span>GitHub ID</span>
+      <span>得分</span>
+    </div>
+    <ol class="qemu-leaderboard__rows">
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="1" data-github-id="fbt1709" data-score="100" data-total-score="100" data-run-time="2026-04-13 10:35 UTC">
+        <span class="qemu-leaderboard__rank">1</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/fbt1709" target="_blank" rel="noopener noreferrer">fbt1709</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="2" data-github-id="Lfan-ke" data-score="100" data-total-score="100" data-run-time="2026-04-15 00:55 UTC">
+        <span class="qemu-leaderboard__rank">2</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Lfan-ke" target="_blank" rel="noopener noreferrer">Lfan-ke</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="3" data-github-id="Plucky923" data-score="100" data-total-score="100" data-run-time="2026-04-17 05:55 UTC">
+        <span class="qemu-leaderboard__rank">3</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Plucky923" target="_blank" rel="noopener noreferrer">Plucky923</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="4" data-github-id="Dirinkbottle" data-score="100" data-total-score="100" data-run-time="2026-04-17 11:00 UTC">
+        <span class="qemu-leaderboard__rank">4</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Dirinkbottle" target="_blank" rel="noopener noreferrer">Dirinkbottle</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="5" data-github-id="clsfantasy" data-score="100" data-total-score="100" data-run-time="2026-04-18 09:39 UTC">
+        <span class="qemu-leaderboard__rank">5</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/clsfantasy" target="_blank" rel="noopener noreferrer">clsfantasy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="6" data-github-id="csmyx" data-score="100" data-total-score="100" data-run-time="2026-04-18 15:58 UTC">
+        <span class="qemu-leaderboard__rank">6</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csmyx" target="_blank" rel="noopener noreferrer">csmyx</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="7" data-github-id="coldriver-chen" data-score="100" data-total-score="100" data-run-time="2026-04-20 04:19 UTC">
+        <span class="qemu-leaderboard__rank">7</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/coldriver-chen" target="_blank" rel="noopener noreferrer">coldriver-chen</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="8" data-github-id="h1y2g3l4y5" data-score="100" data-total-score="100" data-run-time="2026-04-21 15:57 UTC">
+        <span class="qemu-leaderboard__rank">8</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/h1y2g3l4y5" target="_blank" rel="noopener noreferrer">h1y2g3l4y5</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="9" data-github-id="anicbeer" data-score="100" data-total-score="100" data-run-time="2026-04-22 13:55 UTC">
+        <span class="qemu-leaderboard__rank">9</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/anicbeer" target="_blank" rel="noopener noreferrer">anicbeer</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="10" data-github-id="srcres258" data-score="100" data-total-score="100" data-run-time="2026-04-24 03:17 UTC">
+        <span class="qemu-leaderboard__rank">10</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srcres258" target="_blank" rel="noopener noreferrer">srcres258</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="11" data-github-id="KeyBor" data-score="100" data-total-score="100" data-run-time="2026-04-28 05:52 UTC">
+        <span class="qemu-leaderboard__rank">11</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/KeyBor" target="_blank" rel="noopener noreferrer">KeyBor</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="12" data-github-id="adgnaf" data-score="100" data-total-score="100" data-run-time="2026-04-28 07:09 UTC">
+        <span class="qemu-leaderboard__rank">12</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/adgnaf" target="_blank" rel="noopener noreferrer">adgnaf</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="13" data-github-id="PingGuoMiaoMiao" data-score="100" data-total-score="100" data-run-time="2026-05-02 16:42 UTC">
+        <span class="qemu-leaderboard__rank">13</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/PingGuoMiaoMiao" target="_blank" rel="noopener noreferrer">PingGuoMiaoMiao</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="14" data-github-id="lusixing" data-score="100" data-total-score="100" data-run-time="2026-05-04 09:14 UTC">
+        <span class="qemu-leaderboard__rank">14</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lusixing" target="_blank" rel="noopener noreferrer">lusixing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="15" data-github-id="Sutter099" data-score="100" data-total-score="100" data-run-time="2026-05-07 14:54 UTC">
+        <span class="qemu-leaderboard__rank">15</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sutter099" target="_blank" rel="noopener noreferrer">Sutter099</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="16" data-github-id="skinterqwe" data-score="100" data-total-score="100" data-run-time="2026-05-08 01:14 UTC">
+        <span class="qemu-leaderboard__rank">16</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/skinterqwe" target="_blank" rel="noopener noreferrer">skinterqwe</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="17" data-github-id="scrail" data-score="100" data-total-score="100" data-run-time="2026-05-13 08:10 UTC">
+        <span class="qemu-leaderboard__rank">17</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/scrail" target="_blank" rel="noopener noreferrer">scrail</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="18" data-github-id="silicalet" data-score="100" data-total-score="100" data-run-time="2026-05-14 12:14 UTC">
+        <span class="qemu-leaderboard__rank">18</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/silicalet" target="_blank" rel="noopener noreferrer">silicalet</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="19" data-github-id="trace1729" data-score="100" data-total-score="100" data-run-time="2026-05-20 06:54 UTC">
+        <span class="qemu-leaderboard__rank">19</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/trace1729" target="_blank" rel="noopener noreferrer">trace1729</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="20" data-github-id="vsvnakers" data-score="100" data-total-score="100" data-run-time="2026-05-23 15:56 UTC">
+        <span class="qemu-leaderboard__rank">20</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/vsvnakers" target="_blank" rel="noopener noreferrer">vsvnakers</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="21" data-github-id="bbbbbq" data-score="100" data-total-score="100" data-run-time="2026-05-23 16:58 UTC">
+        <span class="qemu-leaderboard__rank">21</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/bbbbbq" target="_blank" rel="noopener noreferrer">bbbbbq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="22" data-github-id="enlist12" data-score="100" data-total-score="100" data-run-time="2026-05-26 04:20 UTC">
+        <span class="qemu-leaderboard__rank">22</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/enlist12" target="_blank" rel="noopener noreferrer">enlist12</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="23" data-github-id="yuanyiboyyb" data-score="100" data-total-score="100" data-run-time="2026-05-27 12:35 UTC">
+        <span class="qemu-leaderboard__rank">23</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yuanyiboyyb" target="_blank" rel="noopener noreferrer">yuanyiboyyb</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="24" data-github-id="Eclipse-Arrebol" data-score="100" data-total-score="100" data-run-time="2026-05-30 12:59 UTC">
+        <span class="qemu-leaderboard__rank">24</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Eclipse-Arrebol" target="_blank" rel="noopener noreferrer">Eclipse-Arrebol</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="25" data-github-id="flespark" data-score="100" data-total-score="100" data-run-time="2026-06-02 10:28 UTC">
+        <span class="qemu-leaderboard__rank">25</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flespark" target="_blank" rel="noopener noreferrer">flespark</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="26" data-github-id="2zuqisong" data-score="100" data-total-score="100" data-run-time="2026-06-05 07:16 UTC">
+        <span class="qemu-leaderboard__rank">26</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/2zuqisong" target="_blank" rel="noopener noreferrer">2zuqisong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="27" data-github-id="srhashdh" data-score="100" data-total-score="100" data-run-time="2026-06-05 09:16 UTC">
+        <span class="qemu-leaderboard__rank">27</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srhashdh" target="_blank" rel="noopener noreferrer">srhashdh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="28" data-github-id="random25160765-collab" data-score="100" data-total-score="100" data-run-time="2026-06-15 15:10 UTC">
+        <span class="qemu-leaderboard__rank">28</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/random25160765-collab" target="_blank" rel="noopener noreferrer">random25160765-collab</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="29" data-github-id="First-da" data-score="100" data-total-score="100" data-run-time="2026-06-21 05:26 UTC">
+        <span class="qemu-leaderboard__rank">29</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/First-da" target="_blank" rel="noopener noreferrer">First-da</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="30" data-github-id="asdfgh870" data-score="100" data-total-score="100" data-run-time="2026-06-21 14:04 UTC">
+        <span class="qemu-leaderboard__rank">30</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/asdfgh870" target="_blank" rel="noopener noreferrer">asdfgh870</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="31" data-github-id="WhiteBearI" data-score="100" data-total-score="100" data-run-time="2026-06-23 13:38 UTC">
+        <span class="qemu-leaderboard__rank">31</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/WhiteBearI" target="_blank" rel="noopener noreferrer">WhiteBearI</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="32" data-github-id="Aozaki-aok0" data-score="100" data-total-score="100" data-run-time="2026-07-08 07:50 UTC">
+        <span class="qemu-leaderboard__rank">32</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Aozaki-aok0" target="_blank" rel="noopener noreferrer">Aozaki-aok0</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="33" data-github-id="Opadc" data-score="60" data-total-score="100" data-run-time="2026-05-27 13:58 UTC">
+        <span class="qemu-leaderboard__rank">33</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Opadc" target="_blank" rel="noopener noreferrer">Opadc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>60</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 60.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="34" data-github-id="mhubing" data-score="50" data-total-score="100" data-run-time="2026-04-27 01:56 UTC">
+        <span class="qemu-leaderboard__rank">34</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/mhubing" target="_blank" rel="noopener noreferrer">mhubing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>50</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 50.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="35" data-github-id="litianxing2016" data-score="10" data-total-score="100" data-run-time="2026-07-02 09:36 UTC">
+        <span class="qemu-leaderboard__rank">35</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/litianxing2016" target="_blank" rel="noopener noreferrer">litianxing2016</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+    </ol>
+  </div>
+</section>

--- a/docs/leaderboards/2026/professional/gpgpu.md
+++ b/docs/leaderboards/2026/professional/gpgpu.md
@@ -1,81 +1,625 @@
 # QEMU 训练营 2026 专业阶段 GPGPU 方向排行榜
 
-[CPU 方向](cpu.md) | [SoC 方向](soc.md) | [**GPGPU 方向**](gpgpu.md) | [Rust 方向](rust.md)
+<nav class="qemu-leaderboard-tabs" aria-label="排行榜切换">
+  <a class="qemu-leaderboard-tabs__item" href="cpu.md">CPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="soc.md">SoC 方向</a>
+  <a class="qemu-leaderboard-tabs__item is-active" href="gpgpu.md" aria-current="page">GPGPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="rust.md">Rust 方向</a>
+</nav>
 
-| 排名 | GitHub ID | 得分 | 总分 | 评分 run 时间 |
-| --- | --- | ---: | ---: | --- |
-| 1 | fbt1709 | 100 | 100 | 2026-04-13 10:35 UTC |
-| 2 | Dirinkbottle | 100 | 100 | 2026-04-17 11:00 UTC |
-| 3 | Altersieg | 100 | 100 | 2026-04-21 19:09 UTC |
-| 4 | Codeman-1999 | 100 | 100 | 2026-04-25 10:13 UTC |
-| 5 | KeyBor | 100 | 100 | 2026-04-28 05:52 UTC |
-| 6 | skinterqwe | 100 | 100 | 2026-05-08 01:14 UTC |
-| 7 | 73fc | 100 | 100 | 2026-05-09 12:47 UTC |
-| 8 | scrail | 100 | 100 | 2026-05-13 08:10 UTC |
-| 9 | silicalet | 100 | 100 | 2026-05-14 12:14 UTC |
-| 10 | trace1729 | 100 | 100 | 2026-05-20 06:54 UTC |
-| 11 | Firegooder | 100 | 100 | 2026-05-23 06:15 UTC |
-| 12 | vsvnakers | 100 | 100 | 2026-05-23 15:56 UTC |
-| 13 | bbbbbq | 100 | 100 | 2026-05-23 16:58 UTC |
-| 14 | LiuHongsGitHub | 100 | 100 | 2026-05-30 10:16 UTC |
-| 15 | cn-sys | 100 | 100 | 2026-06-01 19:52 UTC |
-| 16 | xiaoerlang0359-debug | 100 | 100 | 2026-06-07 19:05 UTC |
-| 17 | luis-233 | 100 | 100 | 2026-06-08 02:24 UTC |
-| 18 | jensenojs | 100 | 100 | 2026-06-13 15:50 UTC |
-| 19 | random25160765-collab | 100 | 100 | 2026-06-15 15:10 UTC |
-| 20 | refr66 | 100 | 100 | 2026-06-20 10:58 UTC |
-| 21 | WhiteBearI | 100 | 100 | 2026-06-23 13:38 UTC |
-| 22 | yyxt-xwy | 100 | 100 | 2026-06-24 08:55 UTC |
-| 23 | xiex386 | 100 | 100 | 2026-06-27 16:19 UTC |
-| 24 | dweeqhd | 100 | 100 | 2026-06-29 09:33 UTC |
-| 25 | xxluestc | 82 | 100 | 2026-04-23 16:24 UTC |
-| 26 | ihanzh | 70 | 100 | 2026-04-27 12:01 UTC |
-| 27 | Eclipse-Arrebol | 64 | 100 | 2026-05-30 12:59 UTC |
-| 28 | littlewangzai-orz | 11 | 100 | 2026-06-03 16:29 UTC |
-| 29 | dingtao1 | 5 | 100 | 2026-04-08 15:10 UTC |
-| 30 | Lfan-ke | 5 | 100 | 2026-04-15 00:55 UTC |
-| 31 | Plucky923 | 5 | 100 | 2026-04-17 05:55 UTC |
-| 32 | zevorn | 5 | 100 | 2026-04-18 03:50 UTC |
-| 33 | clsfantasy | 5 | 100 | 2026-04-18 09:39 UTC |
-| 34 | csmyx | 5 | 100 | 2026-04-18 15:58 UTC |
-| 35 | coldriver-chen | 5 | 100 | 2026-04-20 04:19 UTC |
-| 36 | lickoc | 5 | 100 | 2026-04-21 11:11 UTC |
-| 37 | h1y2g3l4y5 | 5 | 100 | 2026-04-21 15:57 UTC |
-| 38 | anicbeer | 5 | 100 | 2026-04-22 13:55 UTC |
-| 39 | Kcang-gna | 5 | 100 | 2026-04-22 13:56 UTC |
-| 40 | srcres258 | 5 | 100 | 2026-04-24 03:17 UTC |
-| 41 | mhubing | 5 | 100 | 2026-04-27 01:56 UTC |
-| 42 | adgnaf | 5 | 100 | 2026-04-28 07:09 UTC |
-| 43 | yunyi1201 | 5 | 100 | 2026-04-30 02:03 UTC |
-| 44 | eternal-echo | 5 | 100 | 2026-05-01 06:43 UTC |
-| 45 | PingGuoMiaoMiao | 5 | 100 | 2026-05-02 16:42 UTC |
-| 46 | lusixing | 5 | 100 | 2026-05-04 09:14 UTC |
-| 47 | destinyFvcker | 5 | 100 | 2026-05-06 14:01 UTC |
-| 48 | Sutter099 | 5 | 100 | 2026-05-07 14:54 UTC |
-| 49 | yunjianshijie | 5 | 100 | 2026-05-10 03:41 UTC |
-| 50 | zhenbaii | 5 | 100 | 2026-05-14 08:58 UTC |
-| 51 | lingqian-gi | 5 | 100 | 2026-05-15 15:09 UTC |
-| 52 | shengdaozm | 5 | 100 | 2026-05-17 07:21 UTC |
-| 53 | ghostdragonzero | 5 | 100 | 2026-05-24 06:35 UTC |
-| 54 | enlist12 | 5 | 100 | 2026-05-26 04:20 UTC |
-| 55 | yuanyiboyyb | 5 | 100 | 2026-05-27 12:35 UTC |
-| 56 | Opadc | 5 | 100 | 2026-05-27 13:58 UTC |
-| 57 | flamboyante | 5 | 100 | 2026-05-28 05:10 UTC |
-| 58 | flespark | 5 | 100 | 2026-06-02 10:28 UTC |
-| 59 | csdjr | 5 | 100 | 2026-06-04 16:32 UTC |
-| 60 | 2zuqisong | 5 | 100 | 2026-06-05 07:16 UTC |
-| 61 | srhashdh | 5 | 100 | 2026-06-05 09:16 UTC |
-| 62 | eyauwag | 5 | 100 | 2026-06-07 07:33 UTC |
-| 63 | Gmikele | 5 | 100 | 2026-06-10 00:16 UTC |
-| 64 | jack-wang-176 | 5 | 100 | 2026-06-10 13:39 UTC |
-| 65 | serf-huik | 5 | 100 | 2026-06-13 03:37 UTC |
-| 66 | dazuo233 | 5 | 100 | 2026-06-14 07:09 UTC |
-| 67 | First-da | 5 | 100 | 2026-06-21 05:26 UTC |
-| 68 | Sunuywq | 5 | 100 | 2026-06-21 10:55 UTC |
-| 69 | asdfgh870 | 5 | 100 | 2026-06-21 14:04 UTC |
-| 70 | jieniguiemmm | 5 | 100 | 2026-07-02 04:06 UTC |
-| 71 | litianxing2016 | 5 | 100 | 2026-07-02 09:36 UTC |
-| 72 | Aozaki-aok0 | 5 | 100 | 2026-07-08 07:50 UTC |
-| 73 | ovwxxwvo | 5 | 100 | 2026-07-08 14:09 UTC |
-
-每天刷新一次｜快照生成时间：2026-07-08 20:50 UTC
+<section class="qemu-leaderboard" aria-label="排行榜">
+  <div class="qemu-leaderboard__header">
+    <div>
+      <div class="qemu-leaderboard__title">专业阶段 · GPGPU 方向</div>
+      <div class="qemu-leaderboard__subtitle">每天刷新一次</div>
+    </div>
+    <div class="qemu-leaderboard__updated">快照生成时间：2026-07-09 14:39 UTC</div>
+  </div>
+  <div class="qemu-leaderboard__metrics">
+    <div class="qemu-leaderboard__metric qemu-leaderboard__metric--primary">
+      <span class="qemu-leaderboard__metric-value">73</span>
+      <span class="qemu-leaderboard__metric-label">上榜人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">24</span>
+      <span class="qemu-leaderboard__metric-label">满分人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">100/100</span>
+      <span class="qemu-leaderboard__metric-label">最高得分</span>
+    </div>
+  </div>
+  <div class="qemu-leaderboard__scroll">
+    <div class="qemu-leaderboard__list-head" aria-hidden="true">
+      <span>排名</span>
+      <span>GitHub ID</span>
+      <span>得分</span>
+    </div>
+    <ol class="qemu-leaderboard__rows">
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="1" data-github-id="fbt1709" data-score="100" data-total-score="100" data-run-time="2026-04-13 10:35 UTC">
+        <span class="qemu-leaderboard__rank">1</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/fbt1709" target="_blank" rel="noopener noreferrer">fbt1709</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="2" data-github-id="Dirinkbottle" data-score="100" data-total-score="100" data-run-time="2026-04-17 11:00 UTC">
+        <span class="qemu-leaderboard__rank">2</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Dirinkbottle" target="_blank" rel="noopener noreferrer">Dirinkbottle</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="3" data-github-id="Altersieg" data-score="100" data-total-score="100" data-run-time="2026-04-21 19:09 UTC">
+        <span class="qemu-leaderboard__rank">3</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Altersieg" target="_blank" rel="noopener noreferrer">Altersieg</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="4" data-github-id="Codeman-1999" data-score="100" data-total-score="100" data-run-time="2026-04-25 10:13 UTC">
+        <span class="qemu-leaderboard__rank">4</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Codeman-1999" target="_blank" rel="noopener noreferrer">Codeman-1999</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="5" data-github-id="KeyBor" data-score="100" data-total-score="100" data-run-time="2026-04-28 05:52 UTC">
+        <span class="qemu-leaderboard__rank">5</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/KeyBor" target="_blank" rel="noopener noreferrer">KeyBor</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="6" data-github-id="skinterqwe" data-score="100" data-total-score="100" data-run-time="2026-05-08 01:14 UTC">
+        <span class="qemu-leaderboard__rank">6</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/skinterqwe" target="_blank" rel="noopener noreferrer">skinterqwe</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="7" data-github-id="73fc" data-score="100" data-total-score="100" data-run-time="2026-05-09 12:47 UTC">
+        <span class="qemu-leaderboard__rank">7</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/73fc" target="_blank" rel="noopener noreferrer">73fc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="8" data-github-id="scrail" data-score="100" data-total-score="100" data-run-time="2026-05-13 08:10 UTC">
+        <span class="qemu-leaderboard__rank">8</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/scrail" target="_blank" rel="noopener noreferrer">scrail</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="9" data-github-id="silicalet" data-score="100" data-total-score="100" data-run-time="2026-05-14 12:14 UTC">
+        <span class="qemu-leaderboard__rank">9</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/silicalet" target="_blank" rel="noopener noreferrer">silicalet</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="10" data-github-id="trace1729" data-score="100" data-total-score="100" data-run-time="2026-05-20 06:54 UTC">
+        <span class="qemu-leaderboard__rank">10</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/trace1729" target="_blank" rel="noopener noreferrer">trace1729</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="11" data-github-id="Firegooder" data-score="100" data-total-score="100" data-run-time="2026-05-23 06:15 UTC">
+        <span class="qemu-leaderboard__rank">11</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Firegooder" target="_blank" rel="noopener noreferrer">Firegooder</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="12" data-github-id="vsvnakers" data-score="100" data-total-score="100" data-run-time="2026-05-23 15:56 UTC">
+        <span class="qemu-leaderboard__rank">12</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/vsvnakers" target="_blank" rel="noopener noreferrer">vsvnakers</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="13" data-github-id="bbbbbq" data-score="100" data-total-score="100" data-run-time="2026-05-23 16:58 UTC">
+        <span class="qemu-leaderboard__rank">13</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/bbbbbq" target="_blank" rel="noopener noreferrer">bbbbbq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="14" data-github-id="LiuHongsGitHub" data-score="100" data-total-score="100" data-run-time="2026-05-30 10:16 UTC">
+        <span class="qemu-leaderboard__rank">14</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/LiuHongsGitHub" target="_blank" rel="noopener noreferrer">LiuHongsGitHub</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="15" data-github-id="cn-sys" data-score="100" data-total-score="100" data-run-time="2026-06-01 19:52 UTC">
+        <span class="qemu-leaderboard__rank">15</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/cn-sys" target="_blank" rel="noopener noreferrer">cn-sys</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="16" data-github-id="xiaoerlang0359-debug" data-score="100" data-total-score="100" data-run-time="2026-06-07 19:05 UTC">
+        <span class="qemu-leaderboard__rank">16</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiaoerlang0359-debug" target="_blank" rel="noopener noreferrer">xiaoerlang0359-debug</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="17" data-github-id="luis-233" data-score="100" data-total-score="100" data-run-time="2026-06-08 02:24 UTC">
+        <span class="qemu-leaderboard__rank">17</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/luis-233" target="_blank" rel="noopener noreferrer">luis-233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="18" data-github-id="jensenojs" data-score="100" data-total-score="100" data-run-time="2026-06-13 15:50 UTC">
+        <span class="qemu-leaderboard__rank">18</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jensenojs" target="_blank" rel="noopener noreferrer">jensenojs</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="19" data-github-id="random25160765-collab" data-score="100" data-total-score="100" data-run-time="2026-06-15 15:10 UTC">
+        <span class="qemu-leaderboard__rank">19</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/random25160765-collab" target="_blank" rel="noopener noreferrer">random25160765-collab</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="20" data-github-id="refr66" data-score="100" data-total-score="100" data-run-time="2026-06-20 10:58 UTC">
+        <span class="qemu-leaderboard__rank">20</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/refr66" target="_blank" rel="noopener noreferrer">refr66</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="21" data-github-id="WhiteBearI" data-score="100" data-total-score="100" data-run-time="2026-06-23 13:38 UTC">
+        <span class="qemu-leaderboard__rank">21</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/WhiteBearI" target="_blank" rel="noopener noreferrer">WhiteBearI</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="22" data-github-id="yyxt-xwy" data-score="100" data-total-score="100" data-run-time="2026-06-24 08:55 UTC">
+        <span class="qemu-leaderboard__rank">22</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yyxt-xwy" target="_blank" rel="noopener noreferrer">yyxt-xwy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="23" data-github-id="xiex386" data-score="100" data-total-score="100" data-run-time="2026-06-27 16:19 UTC">
+        <span class="qemu-leaderboard__rank">23</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiex386" target="_blank" rel="noopener noreferrer">xiex386</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="24" data-github-id="dweeqhd" data-score="100" data-total-score="100" data-run-time="2026-06-29 09:33 UTC">
+        <span class="qemu-leaderboard__rank">24</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dweeqhd" target="_blank" rel="noopener noreferrer">dweeqhd</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="25" data-github-id="xxluestc" data-score="82" data-total-score="100" data-run-time="2026-04-23 16:24 UTC">
+        <span class="qemu-leaderboard__rank">25</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xxluestc" target="_blank" rel="noopener noreferrer">xxluestc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>82</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 82.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="26" data-github-id="ihanzh" data-score="70" data-total-score="100" data-run-time="2026-04-27 12:01 UTC">
+        <span class="qemu-leaderboard__rank">26</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ihanzh" target="_blank" rel="noopener noreferrer">ihanzh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>70</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 70.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="27" data-github-id="Eclipse-Arrebol" data-score="64" data-total-score="100" data-run-time="2026-05-30 12:59 UTC">
+        <span class="qemu-leaderboard__rank">27</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Eclipse-Arrebol" target="_blank" rel="noopener noreferrer">Eclipse-Arrebol</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>64</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 64.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="28" data-github-id="littlewangzai-orz" data-score="11" data-total-score="100" data-run-time="2026-06-03 16:29 UTC">
+        <span class="qemu-leaderboard__rank">28</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/littlewangzai-orz" target="_blank" rel="noopener noreferrer">littlewangzai-orz</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>11</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 11.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="29" data-github-id="dingtao1" data-score="5" data-total-score="100" data-run-time="2026-04-08 15:10 UTC">
+        <span class="qemu-leaderboard__rank">29</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dingtao1" target="_blank" rel="noopener noreferrer">dingtao1</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="30" data-github-id="Lfan-ke" data-score="5" data-total-score="100" data-run-time="2026-04-15 00:55 UTC">
+        <span class="qemu-leaderboard__rank">30</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Lfan-ke" target="_blank" rel="noopener noreferrer">Lfan-ke</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="31" data-github-id="Plucky923" data-score="5" data-total-score="100" data-run-time="2026-04-17 05:55 UTC">
+        <span class="qemu-leaderboard__rank">31</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Plucky923" target="_blank" rel="noopener noreferrer">Plucky923</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="32" data-github-id="zevorn" data-score="5" data-total-score="100" data-run-time="2026-04-18 03:50 UTC">
+        <span class="qemu-leaderboard__rank">32</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zevorn" target="_blank" rel="noopener noreferrer">zevorn</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="33" data-github-id="clsfantasy" data-score="5" data-total-score="100" data-run-time="2026-04-18 09:39 UTC">
+        <span class="qemu-leaderboard__rank">33</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/clsfantasy" target="_blank" rel="noopener noreferrer">clsfantasy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="34" data-github-id="csmyx" data-score="5" data-total-score="100" data-run-time="2026-04-18 15:58 UTC">
+        <span class="qemu-leaderboard__rank">34</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csmyx" target="_blank" rel="noopener noreferrer">csmyx</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="35" data-github-id="coldriver-chen" data-score="5" data-total-score="100" data-run-time="2026-04-20 04:19 UTC">
+        <span class="qemu-leaderboard__rank">35</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/coldriver-chen" target="_blank" rel="noopener noreferrer">coldriver-chen</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="36" data-github-id="lickoc" data-score="5" data-total-score="100" data-run-time="2026-04-21 11:11 UTC">
+        <span class="qemu-leaderboard__rank">36</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lickoc" target="_blank" rel="noopener noreferrer">lickoc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="37" data-github-id="h1y2g3l4y5" data-score="5" data-total-score="100" data-run-time="2026-04-21 15:57 UTC">
+        <span class="qemu-leaderboard__rank">37</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/h1y2g3l4y5" target="_blank" rel="noopener noreferrer">h1y2g3l4y5</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="38" data-github-id="anicbeer" data-score="5" data-total-score="100" data-run-time="2026-04-22 13:55 UTC">
+        <span class="qemu-leaderboard__rank">38</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/anicbeer" target="_blank" rel="noopener noreferrer">anicbeer</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="39" data-github-id="Kcang-gna" data-score="5" data-total-score="100" data-run-time="2026-04-22 13:56 UTC">
+        <span class="qemu-leaderboard__rank">39</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Kcang-gna" target="_blank" rel="noopener noreferrer">Kcang-gna</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="40" data-github-id="srcres258" data-score="5" data-total-score="100" data-run-time="2026-04-24 03:17 UTC">
+        <span class="qemu-leaderboard__rank">40</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srcres258" target="_blank" rel="noopener noreferrer">srcres258</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="41" data-github-id="mhubing" data-score="5" data-total-score="100" data-run-time="2026-04-27 01:56 UTC">
+        <span class="qemu-leaderboard__rank">41</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/mhubing" target="_blank" rel="noopener noreferrer">mhubing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="42" data-github-id="adgnaf" data-score="5" data-total-score="100" data-run-time="2026-04-28 07:09 UTC">
+        <span class="qemu-leaderboard__rank">42</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/adgnaf" target="_blank" rel="noopener noreferrer">adgnaf</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="43" data-github-id="yunyi1201" data-score="5" data-total-score="100" data-run-time="2026-04-30 02:03 UTC">
+        <span class="qemu-leaderboard__rank">43</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunyi1201" target="_blank" rel="noopener noreferrer">yunyi1201</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="44" data-github-id="eternal-echo" data-score="5" data-total-score="100" data-run-time="2026-05-01 06:43 UTC">
+        <span class="qemu-leaderboard__rank">44</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eternal-echo" target="_blank" rel="noopener noreferrer">eternal-echo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="45" data-github-id="PingGuoMiaoMiao" data-score="5" data-total-score="100" data-run-time="2026-05-02 16:42 UTC">
+        <span class="qemu-leaderboard__rank">45</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/PingGuoMiaoMiao" target="_blank" rel="noopener noreferrer">PingGuoMiaoMiao</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="46" data-github-id="lusixing" data-score="5" data-total-score="100" data-run-time="2026-05-04 09:14 UTC">
+        <span class="qemu-leaderboard__rank">46</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lusixing" target="_blank" rel="noopener noreferrer">lusixing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="47" data-github-id="destinyFvcker" data-score="5" data-total-score="100" data-run-time="2026-05-06 14:01 UTC">
+        <span class="qemu-leaderboard__rank">47</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/destinyFvcker" target="_blank" rel="noopener noreferrer">destinyFvcker</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="48" data-github-id="Sutter099" data-score="5" data-total-score="100" data-run-time="2026-05-07 14:54 UTC">
+        <span class="qemu-leaderboard__rank">48</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sutter099" target="_blank" rel="noopener noreferrer">Sutter099</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="49" data-github-id="yunjianshijie" data-score="5" data-total-score="100" data-run-time="2026-05-10 03:41 UTC">
+        <span class="qemu-leaderboard__rank">49</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunjianshijie" target="_blank" rel="noopener noreferrer">yunjianshijie</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="50" data-github-id="zhenbaii" data-score="5" data-total-score="100" data-run-time="2026-05-14 08:58 UTC">
+        <span class="qemu-leaderboard__rank">50</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zhenbaii" target="_blank" rel="noopener noreferrer">zhenbaii</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="51" data-github-id="lingqian-gi" data-score="5" data-total-score="100" data-run-time="2026-05-15 15:09 UTC">
+        <span class="qemu-leaderboard__rank">51</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lingqian-gi" target="_blank" rel="noopener noreferrer">lingqian-gi</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="52" data-github-id="shengdaozm" data-score="5" data-total-score="100" data-run-time="2026-05-17 07:21 UTC">
+        <span class="qemu-leaderboard__rank">52</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/shengdaozm" target="_blank" rel="noopener noreferrer">shengdaozm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="53" data-github-id="ghostdragonzero" data-score="5" data-total-score="100" data-run-time="2026-05-24 06:35 UTC">
+        <span class="qemu-leaderboard__rank">53</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ghostdragonzero" target="_blank" rel="noopener noreferrer">ghostdragonzero</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="54" data-github-id="enlist12" data-score="5" data-total-score="100" data-run-time="2026-05-26 04:20 UTC">
+        <span class="qemu-leaderboard__rank">54</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/enlist12" target="_blank" rel="noopener noreferrer">enlist12</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="55" data-github-id="yuanyiboyyb" data-score="5" data-total-score="100" data-run-time="2026-05-27 12:35 UTC">
+        <span class="qemu-leaderboard__rank">55</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yuanyiboyyb" target="_blank" rel="noopener noreferrer">yuanyiboyyb</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="56" data-github-id="Opadc" data-score="5" data-total-score="100" data-run-time="2026-05-27 13:58 UTC">
+        <span class="qemu-leaderboard__rank">56</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Opadc" target="_blank" rel="noopener noreferrer">Opadc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="57" data-github-id="flamboyante" data-score="5" data-total-score="100" data-run-time="2026-05-28 05:10 UTC">
+        <span class="qemu-leaderboard__rank">57</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flamboyante" target="_blank" rel="noopener noreferrer">flamboyante</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="58" data-github-id="flespark" data-score="5" data-total-score="100" data-run-time="2026-06-02 10:28 UTC">
+        <span class="qemu-leaderboard__rank">58</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flespark" target="_blank" rel="noopener noreferrer">flespark</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="59" data-github-id="csdjr" data-score="5" data-total-score="100" data-run-time="2026-06-04 16:32 UTC">
+        <span class="qemu-leaderboard__rank">59</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csdjr" target="_blank" rel="noopener noreferrer">csdjr</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="60" data-github-id="2zuqisong" data-score="5" data-total-score="100" data-run-time="2026-06-05 07:16 UTC">
+        <span class="qemu-leaderboard__rank">60</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/2zuqisong" target="_blank" rel="noopener noreferrer">2zuqisong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="61" data-github-id="srhashdh" data-score="5" data-total-score="100" data-run-time="2026-06-05 09:16 UTC">
+        <span class="qemu-leaderboard__rank">61</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srhashdh" target="_blank" rel="noopener noreferrer">srhashdh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="62" data-github-id="eyauwag" data-score="5" data-total-score="100" data-run-time="2026-06-07 07:33 UTC">
+        <span class="qemu-leaderboard__rank">62</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eyauwag" target="_blank" rel="noopener noreferrer">eyauwag</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="63" data-github-id="Gmikele" data-score="5" data-total-score="100" data-run-time="2026-06-10 00:16 UTC">
+        <span class="qemu-leaderboard__rank">63</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Gmikele" target="_blank" rel="noopener noreferrer">Gmikele</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="64" data-github-id="jack-wang-176" data-score="5" data-total-score="100" data-run-time="2026-06-10 13:39 UTC">
+        <span class="qemu-leaderboard__rank">64</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jack-wang-176" target="_blank" rel="noopener noreferrer">jack-wang-176</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="65" data-github-id="serf-huik" data-score="5" data-total-score="100" data-run-time="2026-06-13 03:37 UTC">
+        <span class="qemu-leaderboard__rank">65</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/serf-huik" target="_blank" rel="noopener noreferrer">serf-huik</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="66" data-github-id="dazuo233" data-score="5" data-total-score="100" data-run-time="2026-06-14 07:09 UTC">
+        <span class="qemu-leaderboard__rank">66</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dazuo233" target="_blank" rel="noopener noreferrer">dazuo233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="67" data-github-id="First-da" data-score="5" data-total-score="100" data-run-time="2026-06-21 05:26 UTC">
+        <span class="qemu-leaderboard__rank">67</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/First-da" target="_blank" rel="noopener noreferrer">First-da</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="68" data-github-id="Sunuywq" data-score="5" data-total-score="100" data-run-time="2026-06-21 10:55 UTC">
+        <span class="qemu-leaderboard__rank">68</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sunuywq" target="_blank" rel="noopener noreferrer">Sunuywq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="69" data-github-id="asdfgh870" data-score="5" data-total-score="100" data-run-time="2026-06-21 14:04 UTC">
+        <span class="qemu-leaderboard__rank">69</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/asdfgh870" target="_blank" rel="noopener noreferrer">asdfgh870</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="70" data-github-id="jieniguiemmm" data-score="5" data-total-score="100" data-run-time="2026-07-02 04:06 UTC">
+        <span class="qemu-leaderboard__rank">70</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jieniguiemmm" target="_blank" rel="noopener noreferrer">jieniguiemmm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="71" data-github-id="litianxing2016" data-score="5" data-total-score="100" data-run-time="2026-07-02 09:36 UTC">
+        <span class="qemu-leaderboard__rank">71</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/litianxing2016" target="_blank" rel="noopener noreferrer">litianxing2016</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="72" data-github-id="Aozaki-aok0" data-score="5" data-total-score="100" data-run-time="2026-07-08 07:50 UTC">
+        <span class="qemu-leaderboard__rank">72</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Aozaki-aok0" target="_blank" rel="noopener noreferrer">Aozaki-aok0</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="73" data-github-id="ovwxxwvo" data-score="5" data-total-score="100" data-run-time="2026-07-08 14:09 UTC">
+        <span class="qemu-leaderboard__rank">73</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ovwxxwvo" target="_blank" rel="noopener noreferrer">ovwxxwvo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>5</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 5.00%"></span></span>
+        </span>
+      </li>
+    </ol>
+  </div>
+</section>

--- a/docs/leaderboards/2026/professional/rust.md
+++ b/docs/leaderboards/2026/professional/rust.md
@@ -1,81 +1,625 @@
 # QEMU 训练营 2026 专业阶段 Rust 方向排行榜
 
-[CPU 方向](cpu.md) | [SoC 方向](soc.md) | [GPGPU 方向](gpgpu.md) | [**Rust 方向**](rust.md)
+<nav class="qemu-leaderboard-tabs" aria-label="排行榜切换">
+  <a class="qemu-leaderboard-tabs__item" href="cpu.md">CPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="soc.md">SoC 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="gpgpu.md">GPGPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item is-active" href="rust.md" aria-current="page">Rust 方向</a>
+</nav>
 
-| 排名 | GitHub ID | 得分 | 总分 | 评分 run 时间 |
-| --- | --- | ---: | ---: | --- |
-| 1 | Plucky923 | 100 | 100 | 2026-04-17 05:55 UTC |
-| 2 | Kcang-gna | 100 | 100 | 2026-04-22 13:56 UTC |
-| 3 | ihanzh | 100 | 100 | 2026-04-27 12:01 UTC |
-| 4 | silicalet | 100 | 100 | 2026-05-14 12:14 UTC |
-| 5 | vsvnakers | 100 | 100 | 2026-05-23 15:56 UTC |
-| 6 | ghostdragonzero | 100 | 100 | 2026-05-24 06:35 UTC |
-| 7 | eyauwag | 100 | 100 | 2026-06-07 07:33 UTC |
-| 8 | random25160765-collab | 100 | 100 | 2026-06-15 15:10 UTC |
-| 9 | Lfan-ke | 30 | 100 | 2026-04-15 00:55 UTC |
-| 10 | lickoc | 30 | 100 | 2026-04-21 11:11 UTC |
-| 11 | jack-wang-176 | 30 | 100 | 2026-06-10 13:39 UTC |
-| 12 | ovwxxwvo | 30 | 100 | 2026-07-08 14:09 UTC |
-| 13 | dingtao1 | 10 | 100 | 2026-04-08 13:18 UTC |
-| 14 | fbt1709 | 10 | 100 | 2026-04-13 10:35 UTC |
-| 15 | Dirinkbottle | 10 | 100 | 2026-04-17 11:00 UTC |
-| 16 | zevorn | 10 | 100 | 2026-04-18 03:50 UTC |
-| 17 | clsfantasy | 10 | 100 | 2026-04-18 09:39 UTC |
-| 18 | csmyx | 10 | 100 | 2026-04-18 15:58 UTC |
-| 19 | coldriver-chen | 10 | 100 | 2026-04-20 04:19 UTC |
-| 20 | h1y2g3l4y5 | 10 | 100 | 2026-04-21 15:57 UTC |
-| 21 | Altersieg | 10 | 100 | 2026-04-21 19:09 UTC |
-| 22 | anicbeer | 10 | 100 | 2026-04-22 13:55 UTC |
-| 23 | xxluestc | 10 | 100 | 2026-04-23 16:24 UTC |
-| 24 | srcres258 | 10 | 100 | 2026-04-24 03:17 UTC |
-| 25 | Codeman-1999 | 10 | 100 | 2026-04-25 10:13 UTC |
-| 26 | mhubing | 10 | 100 | 2026-04-27 01:56 UTC |
-| 27 | KeyBor | 10 | 100 | 2026-04-28 05:52 UTC |
-| 28 | adgnaf | 10 | 100 | 2026-04-28 07:09 UTC |
-| 29 | yunyi1201 | 10 | 100 | 2026-04-30 02:03 UTC |
-| 30 | eternal-echo | 10 | 100 | 2026-05-01 06:43 UTC |
-| 31 | PingGuoMiaoMiao | 10 | 100 | 2026-05-02 16:42 UTC |
-| 32 | lusixing | 10 | 100 | 2026-05-04 09:14 UTC |
-| 33 | destinyFvcker | 10 | 100 | 2026-05-06 14:01 UTC |
-| 34 | Sutter099 | 10 | 100 | 2026-05-07 14:54 UTC |
-| 35 | skinterqwe | 10 | 100 | 2026-05-08 01:14 UTC |
-| 36 | 73fc | 10 | 100 | 2026-05-09 12:47 UTC |
-| 37 | yunjianshijie | 10 | 100 | 2026-05-10 03:41 UTC |
-| 38 | scrail | 10 | 100 | 2026-05-13 08:10 UTC |
-| 39 | zhenbaii | 10 | 100 | 2026-05-14 08:58 UTC |
-| 40 | lingqian-gi | 10 | 100 | 2026-05-15 15:09 UTC |
-| 41 | shengdaozm | 10 | 100 | 2026-05-17 07:21 UTC |
-| 42 | trace1729 | 10 | 100 | 2026-05-20 06:54 UTC |
-| 43 | Firegooder | 10 | 100 | 2026-05-23 06:15 UTC |
-| 44 | bbbbbq | 10 | 100 | 2026-05-23 16:58 UTC |
-| 45 | enlist12 | 10 | 100 | 2026-05-26 04:20 UTC |
-| 46 | yuanyiboyyb | 10 | 100 | 2026-05-27 12:35 UTC |
-| 47 | Opadc | 10 | 100 | 2026-05-27 13:58 UTC |
-| 48 | flamboyante | 10 | 100 | 2026-05-28 05:10 UTC |
-| 49 | LiuHongsGitHub | 10 | 100 | 2026-05-30 10:16 UTC |
-| 50 | Eclipse-Arrebol | 10 | 100 | 2026-05-30 12:59 UTC |
-| 51 | cn-sys | 10 | 100 | 2026-06-01 19:52 UTC |
-| 52 | flespark | 10 | 100 | 2026-06-02 10:28 UTC |
-| 53 | littlewangzai-orz | 10 | 100 | 2026-06-03 16:29 UTC |
-| 54 | csdjr | 10 | 100 | 2026-06-04 16:32 UTC |
-| 55 | 2zuqisong | 10 | 100 | 2026-06-05 07:16 UTC |
-| 56 | srhashdh | 10 | 100 | 2026-06-05 09:16 UTC |
-| 57 | xiaoerlang0359-debug | 10 | 100 | 2026-06-07 19:05 UTC |
-| 58 | luis-233 | 10 | 100 | 2026-06-08 02:24 UTC |
-| 59 | Gmikele | 10 | 100 | 2026-06-10 00:16 UTC |
-| 60 | rhbfc | 10 | 100 | 2026-06-11 06:10 UTC |
-| 61 | serf-huik | 10 | 100 | 2026-06-13 03:37 UTC |
-| 62 | jensenojs | 10 | 100 | 2026-06-13 15:50 UTC |
-| 63 | dazuo233 | 10 | 100 | 2026-06-14 07:09 UTC |
-| 64 | refr66 | 10 | 100 | 2026-06-20 10:58 UTC |
-| 65 | First-da | 10 | 100 | 2026-06-21 05:26 UTC |
-| 66 | asdfgh870 | 10 | 100 | 2026-06-21 14:04 UTC |
-| 67 | WhiteBearI | 10 | 100 | 2026-06-23 13:38 UTC |
-| 68 | yyxt-xwy | 10 | 100 | 2026-06-24 08:55 UTC |
-| 69 | xiex386 | 10 | 100 | 2026-06-27 16:19 UTC |
-| 70 | dweeqhd | 10 | 100 | 2026-06-29 09:33 UTC |
-| 71 | jieniguiemmm | 10 | 100 | 2026-07-02 04:06 UTC |
-| 72 | litianxing2016 | 10 | 100 | 2026-07-02 09:36 UTC |
-| 73 | Aozaki-aok0 | 10 | 100 | 2026-07-08 07:50 UTC |
-
-每天刷新一次｜快照生成时间：2026-07-08 20:50 UTC
+<section class="qemu-leaderboard" aria-label="排行榜">
+  <div class="qemu-leaderboard__header">
+    <div>
+      <div class="qemu-leaderboard__title">专业阶段 · Rust 方向</div>
+      <div class="qemu-leaderboard__subtitle">每天刷新一次</div>
+    </div>
+    <div class="qemu-leaderboard__updated">快照生成时间：2026-07-09 14:39 UTC</div>
+  </div>
+  <div class="qemu-leaderboard__metrics">
+    <div class="qemu-leaderboard__metric qemu-leaderboard__metric--primary">
+      <span class="qemu-leaderboard__metric-value">73</span>
+      <span class="qemu-leaderboard__metric-label">上榜人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">8</span>
+      <span class="qemu-leaderboard__metric-label">满分人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">100/100</span>
+      <span class="qemu-leaderboard__metric-label">最高得分</span>
+    </div>
+  </div>
+  <div class="qemu-leaderboard__scroll">
+    <div class="qemu-leaderboard__list-head" aria-hidden="true">
+      <span>排名</span>
+      <span>GitHub ID</span>
+      <span>得分</span>
+    </div>
+    <ol class="qemu-leaderboard__rows">
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="1" data-github-id="Plucky923" data-score="100" data-total-score="100" data-run-time="2026-04-17 05:55 UTC">
+        <span class="qemu-leaderboard__rank">1</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Plucky923" target="_blank" rel="noopener noreferrer">Plucky923</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="2" data-github-id="Kcang-gna" data-score="100" data-total-score="100" data-run-time="2026-04-22 13:56 UTC">
+        <span class="qemu-leaderboard__rank">2</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Kcang-gna" target="_blank" rel="noopener noreferrer">Kcang-gna</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="3" data-github-id="ihanzh" data-score="100" data-total-score="100" data-run-time="2026-04-27 12:01 UTC">
+        <span class="qemu-leaderboard__rank">3</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ihanzh" target="_blank" rel="noopener noreferrer">ihanzh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="4" data-github-id="silicalet" data-score="100" data-total-score="100" data-run-time="2026-05-14 12:14 UTC">
+        <span class="qemu-leaderboard__rank">4</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/silicalet" target="_blank" rel="noopener noreferrer">silicalet</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="5" data-github-id="vsvnakers" data-score="100" data-total-score="100" data-run-time="2026-05-23 15:56 UTC">
+        <span class="qemu-leaderboard__rank">5</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/vsvnakers" target="_blank" rel="noopener noreferrer">vsvnakers</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="6" data-github-id="ghostdragonzero" data-score="100" data-total-score="100" data-run-time="2026-05-24 06:35 UTC">
+        <span class="qemu-leaderboard__rank">6</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ghostdragonzero" target="_blank" rel="noopener noreferrer">ghostdragonzero</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="7" data-github-id="eyauwag" data-score="100" data-total-score="100" data-run-time="2026-06-07 07:33 UTC">
+        <span class="qemu-leaderboard__rank">7</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eyauwag" target="_blank" rel="noopener noreferrer">eyauwag</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="8" data-github-id="random25160765-collab" data-score="100" data-total-score="100" data-run-time="2026-06-15 15:10 UTC">
+        <span class="qemu-leaderboard__rank">8</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/random25160765-collab" target="_blank" rel="noopener noreferrer">random25160765-collab</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="9" data-github-id="Lfan-ke" data-score="30" data-total-score="100" data-run-time="2026-04-15 00:55 UTC">
+        <span class="qemu-leaderboard__rank">9</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Lfan-ke" target="_blank" rel="noopener noreferrer">Lfan-ke</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>30</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 30.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="10" data-github-id="lickoc" data-score="30" data-total-score="100" data-run-time="2026-04-21 11:11 UTC">
+        <span class="qemu-leaderboard__rank">10</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lickoc" target="_blank" rel="noopener noreferrer">lickoc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>30</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 30.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="11" data-github-id="jack-wang-176" data-score="30" data-total-score="100" data-run-time="2026-06-10 13:39 UTC">
+        <span class="qemu-leaderboard__rank">11</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jack-wang-176" target="_blank" rel="noopener noreferrer">jack-wang-176</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>30</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 30.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="12" data-github-id="ovwxxwvo" data-score="30" data-total-score="100" data-run-time="2026-07-08 14:09 UTC">
+        <span class="qemu-leaderboard__rank">12</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ovwxxwvo" target="_blank" rel="noopener noreferrer">ovwxxwvo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>30</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 30.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="13" data-github-id="dingtao1" data-score="10" data-total-score="100" data-run-time="2026-04-08 13:18 UTC">
+        <span class="qemu-leaderboard__rank">13</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dingtao1" target="_blank" rel="noopener noreferrer">dingtao1</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="14" data-github-id="fbt1709" data-score="10" data-total-score="100" data-run-time="2026-04-13 10:35 UTC">
+        <span class="qemu-leaderboard__rank">14</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/fbt1709" target="_blank" rel="noopener noreferrer">fbt1709</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="15" data-github-id="Dirinkbottle" data-score="10" data-total-score="100" data-run-time="2026-04-17 11:00 UTC">
+        <span class="qemu-leaderboard__rank">15</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Dirinkbottle" target="_blank" rel="noopener noreferrer">Dirinkbottle</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="16" data-github-id="zevorn" data-score="10" data-total-score="100" data-run-time="2026-04-18 03:50 UTC">
+        <span class="qemu-leaderboard__rank">16</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zevorn" target="_blank" rel="noopener noreferrer">zevorn</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="17" data-github-id="clsfantasy" data-score="10" data-total-score="100" data-run-time="2026-04-18 09:39 UTC">
+        <span class="qemu-leaderboard__rank">17</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/clsfantasy" target="_blank" rel="noopener noreferrer">clsfantasy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="18" data-github-id="csmyx" data-score="10" data-total-score="100" data-run-time="2026-04-18 15:58 UTC">
+        <span class="qemu-leaderboard__rank">18</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csmyx" target="_blank" rel="noopener noreferrer">csmyx</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="19" data-github-id="coldriver-chen" data-score="10" data-total-score="100" data-run-time="2026-04-20 04:19 UTC">
+        <span class="qemu-leaderboard__rank">19</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/coldriver-chen" target="_blank" rel="noopener noreferrer">coldriver-chen</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="20" data-github-id="h1y2g3l4y5" data-score="10" data-total-score="100" data-run-time="2026-04-21 15:57 UTC">
+        <span class="qemu-leaderboard__rank">20</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/h1y2g3l4y5" target="_blank" rel="noopener noreferrer">h1y2g3l4y5</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="21" data-github-id="Altersieg" data-score="10" data-total-score="100" data-run-time="2026-04-21 19:09 UTC">
+        <span class="qemu-leaderboard__rank">21</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Altersieg" target="_blank" rel="noopener noreferrer">Altersieg</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="22" data-github-id="anicbeer" data-score="10" data-total-score="100" data-run-time="2026-04-22 13:55 UTC">
+        <span class="qemu-leaderboard__rank">22</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/anicbeer" target="_blank" rel="noopener noreferrer">anicbeer</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="23" data-github-id="xxluestc" data-score="10" data-total-score="100" data-run-time="2026-04-23 16:24 UTC">
+        <span class="qemu-leaderboard__rank">23</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xxluestc" target="_blank" rel="noopener noreferrer">xxluestc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="24" data-github-id="srcres258" data-score="10" data-total-score="100" data-run-time="2026-04-24 03:17 UTC">
+        <span class="qemu-leaderboard__rank">24</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srcres258" target="_blank" rel="noopener noreferrer">srcres258</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="25" data-github-id="Codeman-1999" data-score="10" data-total-score="100" data-run-time="2026-04-25 10:13 UTC">
+        <span class="qemu-leaderboard__rank">25</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Codeman-1999" target="_blank" rel="noopener noreferrer">Codeman-1999</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="26" data-github-id="mhubing" data-score="10" data-total-score="100" data-run-time="2026-04-27 01:56 UTC">
+        <span class="qemu-leaderboard__rank">26</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/mhubing" target="_blank" rel="noopener noreferrer">mhubing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="27" data-github-id="KeyBor" data-score="10" data-total-score="100" data-run-time="2026-04-28 05:52 UTC">
+        <span class="qemu-leaderboard__rank">27</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/KeyBor" target="_blank" rel="noopener noreferrer">KeyBor</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="28" data-github-id="adgnaf" data-score="10" data-total-score="100" data-run-time="2026-04-28 07:09 UTC">
+        <span class="qemu-leaderboard__rank">28</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/adgnaf" target="_blank" rel="noopener noreferrer">adgnaf</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="29" data-github-id="yunyi1201" data-score="10" data-total-score="100" data-run-time="2026-04-30 02:03 UTC">
+        <span class="qemu-leaderboard__rank">29</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunyi1201" target="_blank" rel="noopener noreferrer">yunyi1201</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="30" data-github-id="eternal-echo" data-score="10" data-total-score="100" data-run-time="2026-05-01 06:43 UTC">
+        <span class="qemu-leaderboard__rank">30</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eternal-echo" target="_blank" rel="noopener noreferrer">eternal-echo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="31" data-github-id="PingGuoMiaoMiao" data-score="10" data-total-score="100" data-run-time="2026-05-02 16:42 UTC">
+        <span class="qemu-leaderboard__rank">31</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/PingGuoMiaoMiao" target="_blank" rel="noopener noreferrer">PingGuoMiaoMiao</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="32" data-github-id="lusixing" data-score="10" data-total-score="100" data-run-time="2026-05-04 09:14 UTC">
+        <span class="qemu-leaderboard__rank">32</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lusixing" target="_blank" rel="noopener noreferrer">lusixing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="33" data-github-id="destinyFvcker" data-score="10" data-total-score="100" data-run-time="2026-05-06 14:01 UTC">
+        <span class="qemu-leaderboard__rank">33</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/destinyFvcker" target="_blank" rel="noopener noreferrer">destinyFvcker</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="34" data-github-id="Sutter099" data-score="10" data-total-score="100" data-run-time="2026-05-07 14:54 UTC">
+        <span class="qemu-leaderboard__rank">34</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sutter099" target="_blank" rel="noopener noreferrer">Sutter099</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="35" data-github-id="skinterqwe" data-score="10" data-total-score="100" data-run-time="2026-05-08 01:14 UTC">
+        <span class="qemu-leaderboard__rank">35</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/skinterqwe" target="_blank" rel="noopener noreferrer">skinterqwe</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="36" data-github-id="73fc" data-score="10" data-total-score="100" data-run-time="2026-05-09 12:47 UTC">
+        <span class="qemu-leaderboard__rank">36</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/73fc" target="_blank" rel="noopener noreferrer">73fc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="37" data-github-id="yunjianshijie" data-score="10" data-total-score="100" data-run-time="2026-05-10 03:41 UTC">
+        <span class="qemu-leaderboard__rank">37</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunjianshijie" target="_blank" rel="noopener noreferrer">yunjianshijie</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="38" data-github-id="scrail" data-score="10" data-total-score="100" data-run-time="2026-05-13 08:10 UTC">
+        <span class="qemu-leaderboard__rank">38</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/scrail" target="_blank" rel="noopener noreferrer">scrail</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="39" data-github-id="zhenbaii" data-score="10" data-total-score="100" data-run-time="2026-05-14 08:58 UTC">
+        <span class="qemu-leaderboard__rank">39</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zhenbaii" target="_blank" rel="noopener noreferrer">zhenbaii</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="40" data-github-id="lingqian-gi" data-score="10" data-total-score="100" data-run-time="2026-05-15 15:09 UTC">
+        <span class="qemu-leaderboard__rank">40</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lingqian-gi" target="_blank" rel="noopener noreferrer">lingqian-gi</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="41" data-github-id="shengdaozm" data-score="10" data-total-score="100" data-run-time="2026-05-17 07:21 UTC">
+        <span class="qemu-leaderboard__rank">41</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/shengdaozm" target="_blank" rel="noopener noreferrer">shengdaozm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="42" data-github-id="trace1729" data-score="10" data-total-score="100" data-run-time="2026-05-20 06:54 UTC">
+        <span class="qemu-leaderboard__rank">42</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/trace1729" target="_blank" rel="noopener noreferrer">trace1729</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="43" data-github-id="Firegooder" data-score="10" data-total-score="100" data-run-time="2026-05-23 06:15 UTC">
+        <span class="qemu-leaderboard__rank">43</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Firegooder" target="_blank" rel="noopener noreferrer">Firegooder</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="44" data-github-id="bbbbbq" data-score="10" data-total-score="100" data-run-time="2026-05-23 16:58 UTC">
+        <span class="qemu-leaderboard__rank">44</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/bbbbbq" target="_blank" rel="noopener noreferrer">bbbbbq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="45" data-github-id="enlist12" data-score="10" data-total-score="100" data-run-time="2026-05-26 04:20 UTC">
+        <span class="qemu-leaderboard__rank">45</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/enlist12" target="_blank" rel="noopener noreferrer">enlist12</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="46" data-github-id="yuanyiboyyb" data-score="10" data-total-score="100" data-run-time="2026-05-27 12:35 UTC">
+        <span class="qemu-leaderboard__rank">46</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yuanyiboyyb" target="_blank" rel="noopener noreferrer">yuanyiboyyb</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="47" data-github-id="Opadc" data-score="10" data-total-score="100" data-run-time="2026-05-27 13:58 UTC">
+        <span class="qemu-leaderboard__rank">47</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Opadc" target="_blank" rel="noopener noreferrer">Opadc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="48" data-github-id="flamboyante" data-score="10" data-total-score="100" data-run-time="2026-05-28 05:10 UTC">
+        <span class="qemu-leaderboard__rank">48</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flamboyante" target="_blank" rel="noopener noreferrer">flamboyante</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="49" data-github-id="LiuHongsGitHub" data-score="10" data-total-score="100" data-run-time="2026-05-30 10:16 UTC">
+        <span class="qemu-leaderboard__rank">49</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/LiuHongsGitHub" target="_blank" rel="noopener noreferrer">LiuHongsGitHub</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="50" data-github-id="Eclipse-Arrebol" data-score="10" data-total-score="100" data-run-time="2026-05-30 12:59 UTC">
+        <span class="qemu-leaderboard__rank">50</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Eclipse-Arrebol" target="_blank" rel="noopener noreferrer">Eclipse-Arrebol</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="51" data-github-id="cn-sys" data-score="10" data-total-score="100" data-run-time="2026-06-01 19:52 UTC">
+        <span class="qemu-leaderboard__rank">51</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/cn-sys" target="_blank" rel="noopener noreferrer">cn-sys</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="52" data-github-id="flespark" data-score="10" data-total-score="100" data-run-time="2026-06-02 10:28 UTC">
+        <span class="qemu-leaderboard__rank">52</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flespark" target="_blank" rel="noopener noreferrer">flespark</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="53" data-github-id="littlewangzai-orz" data-score="10" data-total-score="100" data-run-time="2026-06-03 16:29 UTC">
+        <span class="qemu-leaderboard__rank">53</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/littlewangzai-orz" target="_blank" rel="noopener noreferrer">littlewangzai-orz</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="54" data-github-id="csdjr" data-score="10" data-total-score="100" data-run-time="2026-06-04 16:32 UTC">
+        <span class="qemu-leaderboard__rank">54</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csdjr" target="_blank" rel="noopener noreferrer">csdjr</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="55" data-github-id="2zuqisong" data-score="10" data-total-score="100" data-run-time="2026-06-05 07:16 UTC">
+        <span class="qemu-leaderboard__rank">55</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/2zuqisong" target="_blank" rel="noopener noreferrer">2zuqisong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="56" data-github-id="srhashdh" data-score="10" data-total-score="100" data-run-time="2026-06-05 09:16 UTC">
+        <span class="qemu-leaderboard__rank">56</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srhashdh" target="_blank" rel="noopener noreferrer">srhashdh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="57" data-github-id="xiaoerlang0359-debug" data-score="10" data-total-score="100" data-run-time="2026-06-07 19:05 UTC">
+        <span class="qemu-leaderboard__rank">57</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiaoerlang0359-debug" target="_blank" rel="noopener noreferrer">xiaoerlang0359-debug</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="58" data-github-id="luis-233" data-score="10" data-total-score="100" data-run-time="2026-06-08 02:24 UTC">
+        <span class="qemu-leaderboard__rank">58</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/luis-233" target="_blank" rel="noopener noreferrer">luis-233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="59" data-github-id="Gmikele" data-score="10" data-total-score="100" data-run-time="2026-06-10 00:16 UTC">
+        <span class="qemu-leaderboard__rank">59</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Gmikele" target="_blank" rel="noopener noreferrer">Gmikele</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="60" data-github-id="rhbfc" data-score="10" data-total-score="100" data-run-time="2026-06-11 06:10 UTC">
+        <span class="qemu-leaderboard__rank">60</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/rhbfc" target="_blank" rel="noopener noreferrer">rhbfc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="61" data-github-id="serf-huik" data-score="10" data-total-score="100" data-run-time="2026-06-13 03:37 UTC">
+        <span class="qemu-leaderboard__rank">61</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/serf-huik" target="_blank" rel="noopener noreferrer">serf-huik</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="62" data-github-id="jensenojs" data-score="10" data-total-score="100" data-run-time="2026-06-13 15:50 UTC">
+        <span class="qemu-leaderboard__rank">62</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jensenojs" target="_blank" rel="noopener noreferrer">jensenojs</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="63" data-github-id="dazuo233" data-score="10" data-total-score="100" data-run-time="2026-06-14 07:09 UTC">
+        <span class="qemu-leaderboard__rank">63</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dazuo233" target="_blank" rel="noopener noreferrer">dazuo233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="64" data-github-id="refr66" data-score="10" data-total-score="100" data-run-time="2026-06-20 10:58 UTC">
+        <span class="qemu-leaderboard__rank">64</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/refr66" target="_blank" rel="noopener noreferrer">refr66</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="65" data-github-id="First-da" data-score="10" data-total-score="100" data-run-time="2026-06-21 05:26 UTC">
+        <span class="qemu-leaderboard__rank">65</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/First-da" target="_blank" rel="noopener noreferrer">First-da</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="66" data-github-id="asdfgh870" data-score="10" data-total-score="100" data-run-time="2026-06-21 14:04 UTC">
+        <span class="qemu-leaderboard__rank">66</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/asdfgh870" target="_blank" rel="noopener noreferrer">asdfgh870</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="67" data-github-id="WhiteBearI" data-score="10" data-total-score="100" data-run-time="2026-06-23 13:38 UTC">
+        <span class="qemu-leaderboard__rank">67</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/WhiteBearI" target="_blank" rel="noopener noreferrer">WhiteBearI</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="68" data-github-id="yyxt-xwy" data-score="10" data-total-score="100" data-run-time="2026-06-24 08:55 UTC">
+        <span class="qemu-leaderboard__rank">68</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yyxt-xwy" target="_blank" rel="noopener noreferrer">yyxt-xwy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="69" data-github-id="xiex386" data-score="10" data-total-score="100" data-run-time="2026-06-27 16:19 UTC">
+        <span class="qemu-leaderboard__rank">69</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiex386" target="_blank" rel="noopener noreferrer">xiex386</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="70" data-github-id="dweeqhd" data-score="10" data-total-score="100" data-run-time="2026-06-29 09:33 UTC">
+        <span class="qemu-leaderboard__rank">70</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dweeqhd" target="_blank" rel="noopener noreferrer">dweeqhd</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="71" data-github-id="jieniguiemmm" data-score="10" data-total-score="100" data-run-time="2026-07-02 04:06 UTC">
+        <span class="qemu-leaderboard__rank">71</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jieniguiemmm" target="_blank" rel="noopener noreferrer">jieniguiemmm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="72" data-github-id="litianxing2016" data-score="10" data-total-score="100" data-run-time="2026-07-02 09:36 UTC">
+        <span class="qemu-leaderboard__rank">72</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/litianxing2016" target="_blank" rel="noopener noreferrer">litianxing2016</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="73" data-github-id="Aozaki-aok0" data-score="10" data-total-score="100" data-run-time="2026-07-08 07:50 UTC">
+        <span class="qemu-leaderboard__rank">73</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Aozaki-aok0" target="_blank" rel="noopener noreferrer">Aozaki-aok0</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+    </ol>
+  </div>
+</section>

--- a/docs/leaderboards/2026/professional/soc.md
+++ b/docs/leaderboards/2026/professional/soc.md
@@ -1,82 +1,633 @@
 # QEMU 训练营 2026 专业阶段 SoC 方向排行榜
 
-[CPU 方向](cpu.md) | [**SoC 方向**](soc.md) | [GPGPU 方向](gpgpu.md) | [Rust 方向](rust.md)
+<nav class="qemu-leaderboard-tabs" aria-label="排行榜切换">
+  <a class="qemu-leaderboard-tabs__item" href="cpu.md">CPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item is-active" href="soc.md" aria-current="page">SoC 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="gpgpu.md">GPGPU 方向</a>
+  <a class="qemu-leaderboard-tabs__item" href="rust.md">Rust 方向</a>
+</nav>
 
-| 排名 | GitHub ID | 得分 | 总分 | 评分 run 时间 |
-| --- | --- | ---: | ---: | --- |
-| 1 | dingtao1 | 100 | 100 | 2026-04-08 15:10 UTC |
-| 2 | fbt1709 | 100 | 100 | 2026-04-13 10:35 UTC |
-| 3 | Plucky923 | 100 | 100 | 2026-04-17 05:55 UTC |
-| 4 | Dirinkbottle | 100 | 100 | 2026-04-17 11:00 UTC |
-| 5 | KeyBor | 100 | 100 | 2026-04-28 05:52 UTC |
-| 6 | eternal-echo | 100 | 100 | 2026-05-01 06:43 UTC |
-| 7 | Sutter099 | 100 | 100 | 2026-05-07 14:54 UTC |
-| 8 | skinterqwe | 100 | 100 | 2026-05-08 01:14 UTC |
-| 9 | zhenbaii | 100 | 100 | 2026-05-14 08:58 UTC |
-| 10 | silicalet | 100 | 100 | 2026-05-14 12:14 UTC |
-| 11 | lingqian-gi | 100 | 100 | 2026-05-15 15:09 UTC |
-| 12 | trace1729 | 100 | 100 | 2026-05-20 06:54 UTC |
-| 13 | vsvnakers | 100 | 100 | 2026-05-23 15:56 UTC |
-| 14 | ghostdragonzero | 100 | 100 | 2026-05-24 06:35 UTC |
-| 15 | yuanyiboyyb | 100 | 100 | 2026-05-27 12:35 UTC |
-| 16 | flamboyante | 100 | 100 | 2026-05-28 05:10 UTC |
-| 17 | Eclipse-Arrebol | 100 | 100 | 2026-05-30 12:59 UTC |
-| 18 | csdjr | 100 | 100 | 2026-06-04 16:32 UTC |
-| 19 | Gmikele | 100 | 100 | 2026-06-10 00:16 UTC |
-| 20 | jack-wang-176 | 100 | 100 | 2026-06-10 13:39 UTC |
-| 21 | rhbfc | 100 | 100 | 2026-06-11 06:10 UTC |
-| 22 | serf-huik | 100 | 100 | 2026-06-13 03:37 UTC |
-| 23 | dazuo233 | 100 | 100 | 2026-06-14 07:09 UTC |
-| 24 | random25160765-collab | 100 | 100 | 2026-06-15 15:10 UTC |
-| 25 | First-da | 100 | 100 | 2026-06-21 05:26 UTC |
-| 26 | Sunuywq | 100 | 100 | 2026-06-21 10:55 UTC |
-| 27 | asdfgh870 | 100 | 100 | 2026-06-21 14:04 UTC |
-| 28 | WhiteBearI | 100 | 100 | 2026-06-23 13:38 UTC |
-| 29 | jieniguiemmm | 100 | 100 | 2026-07-02 04:06 UTC |
-| 30 | PingGuoMiaoMiao | 40 | 100 | 2026-05-02 16:42 UTC |
-| 31 | flespark | 40 | 100 | 2026-06-02 10:28 UTC |
-| 32 | Lfan-ke | 10 | 100 | 2026-04-15 00:55 UTC |
-| 33 | zevorn | 10 | 100 | 2026-04-18 03:50 UTC |
-| 34 | clsfantasy | 10 | 100 | 2026-04-18 09:39 UTC |
-| 35 | csmyx | 10 | 100 | 2026-04-18 15:58 UTC |
-| 36 | coldriver-chen | 10 | 100 | 2026-04-20 04:19 UTC |
-| 37 | lickoc | 10 | 100 | 2026-04-21 11:11 UTC |
-| 38 | h1y2g3l4y5 | 10 | 100 | 2026-04-21 15:57 UTC |
-| 39 | Altersieg | 10 | 100 | 2026-04-21 19:09 UTC |
-| 40 | anicbeer | 10 | 100 | 2026-04-22 13:55 UTC |
-| 41 | Kcang-gna | 10 | 100 | 2026-04-22 13:56 UTC |
-| 42 | xxluestc | 10 | 100 | 2026-04-23 16:24 UTC |
-| 43 | srcres258 | 10 | 100 | 2026-04-24 03:17 UTC |
-| 44 | Codeman-1999 | 10 | 100 | 2026-04-25 10:13 UTC |
-| 45 | mhubing | 10 | 100 | 2026-04-27 01:56 UTC |
-| 46 | ihanzh | 10 | 100 | 2026-04-27 12:01 UTC |
-| 47 | adgnaf | 10 | 100 | 2026-04-28 07:09 UTC |
-| 48 | yunyi1201 | 10 | 100 | 2026-04-30 02:03 UTC |
-| 49 | bbbbbq | 10 | 100 | 2026-05-01 17:31 UTC |
-| 50 | lusixing | 10 | 100 | 2026-05-04 09:14 UTC |
-| 51 | destinyFvcker | 10 | 100 | 2026-05-06 14:01 UTC |
-| 52 | 73fc | 10 | 100 | 2026-05-09 12:47 UTC |
-| 53 | yunjianshijie | 10 | 100 | 2026-05-10 03:41 UTC |
-| 54 | scrail | 10 | 100 | 2026-05-13 08:10 UTC |
-| 55 | shengdaozm | 10 | 100 | 2026-05-17 07:21 UTC |
-| 56 | Firegooder | 10 | 100 | 2026-05-23 06:15 UTC |
-| 57 | enlist12 | 10 | 100 | 2026-05-26 04:20 UTC |
-| 58 | Opadc | 10 | 100 | 2026-05-27 13:58 UTC |
-| 59 | LiuHongsGitHub | 10 | 100 | 2026-05-30 10:16 UTC |
-| 60 | cn-sys | 10 | 100 | 2026-06-01 19:52 UTC |
-| 61 | littlewangzai-orz | 10 | 100 | 2026-06-03 16:29 UTC |
-| 62 | 2zuqisong | 10 | 100 | 2026-06-05 07:16 UTC |
-| 63 | srhashdh | 10 | 100 | 2026-06-05 09:16 UTC |
-| 64 | eyauwag | 10 | 100 | 2026-06-07 07:33 UTC |
-| 65 | xiaoerlang0359-debug | 10 | 100 | 2026-06-07 19:05 UTC |
-| 66 | luis-233 | 10 | 100 | 2026-06-08 02:24 UTC |
-| 67 | jensenojs | 10 | 100 | 2026-06-13 15:50 UTC |
-| 68 | refr66 | 10 | 100 | 2026-06-20 10:58 UTC |
-| 69 | yyxt-xwy | 10 | 100 | 2026-06-24 08:55 UTC |
-| 70 | xiex386 | 10 | 100 | 2026-06-27 16:19 UTC |
-| 71 | dweeqhd | 10 | 100 | 2026-06-29 09:33 UTC |
-| 72 | litianxing2016 | 10 | 100 | 2026-07-02 09:36 UTC |
-| 73 | Aozaki-aok0 | 10 | 100 | 2026-07-08 07:50 UTC |
-| 74 | ovwxxwvo | 10 | 100 | 2026-07-08 14:09 UTC |
-
-每天刷新一次｜快照生成时间：2026-07-08 20:50 UTC
+<section class="qemu-leaderboard" aria-label="排行榜">
+  <div class="qemu-leaderboard__header">
+    <div>
+      <div class="qemu-leaderboard__title">专业阶段 · SoC 方向</div>
+      <div class="qemu-leaderboard__subtitle">每天刷新一次</div>
+    </div>
+    <div class="qemu-leaderboard__updated">快照生成时间：2026-07-09 14:39 UTC</div>
+  </div>
+  <div class="qemu-leaderboard__metrics">
+    <div class="qemu-leaderboard__metric qemu-leaderboard__metric--primary">
+      <span class="qemu-leaderboard__metric-value">74</span>
+      <span class="qemu-leaderboard__metric-label">上榜人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">29</span>
+      <span class="qemu-leaderboard__metric-label">满分人数</span>
+    </div>
+    <div class="qemu-leaderboard__metric">
+      <span class="qemu-leaderboard__metric-value">100/100</span>
+      <span class="qemu-leaderboard__metric-label">最高得分</span>
+    </div>
+  </div>
+  <div class="qemu-leaderboard__scroll">
+    <div class="qemu-leaderboard__list-head" aria-hidden="true">
+      <span>排名</span>
+      <span>GitHub ID</span>
+      <span>得分</span>
+    </div>
+    <ol class="qemu-leaderboard__rows">
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="1" data-github-id="dingtao1" data-score="100" data-total-score="100" data-run-time="2026-04-08 15:10 UTC">
+        <span class="qemu-leaderboard__rank">1</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dingtao1" target="_blank" rel="noopener noreferrer">dingtao1</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="2" data-github-id="fbt1709" data-score="100" data-total-score="100" data-run-time="2026-04-13 10:35 UTC">
+        <span class="qemu-leaderboard__rank">2</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/fbt1709" target="_blank" rel="noopener noreferrer">fbt1709</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row qemu-leaderboard__row--top" data-rank="3" data-github-id="Plucky923" data-score="100" data-total-score="100" data-run-time="2026-04-17 05:55 UTC">
+        <span class="qemu-leaderboard__rank">3</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Plucky923" target="_blank" rel="noopener noreferrer">Plucky923</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="4" data-github-id="Dirinkbottle" data-score="100" data-total-score="100" data-run-time="2026-04-17 11:00 UTC">
+        <span class="qemu-leaderboard__rank">4</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Dirinkbottle" target="_blank" rel="noopener noreferrer">Dirinkbottle</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="5" data-github-id="KeyBor" data-score="100" data-total-score="100" data-run-time="2026-04-28 05:52 UTC">
+        <span class="qemu-leaderboard__rank">5</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/KeyBor" target="_blank" rel="noopener noreferrer">KeyBor</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="6" data-github-id="eternal-echo" data-score="100" data-total-score="100" data-run-time="2026-05-01 06:43 UTC">
+        <span class="qemu-leaderboard__rank">6</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eternal-echo" target="_blank" rel="noopener noreferrer">eternal-echo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="7" data-github-id="Sutter099" data-score="100" data-total-score="100" data-run-time="2026-05-07 14:54 UTC">
+        <span class="qemu-leaderboard__rank">7</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sutter099" target="_blank" rel="noopener noreferrer">Sutter099</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="8" data-github-id="skinterqwe" data-score="100" data-total-score="100" data-run-time="2026-05-08 01:14 UTC">
+        <span class="qemu-leaderboard__rank">8</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/skinterqwe" target="_blank" rel="noopener noreferrer">skinterqwe</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="9" data-github-id="zhenbaii" data-score="100" data-total-score="100" data-run-time="2026-05-14 08:58 UTC">
+        <span class="qemu-leaderboard__rank">9</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zhenbaii" target="_blank" rel="noopener noreferrer">zhenbaii</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="10" data-github-id="silicalet" data-score="100" data-total-score="100" data-run-time="2026-05-14 12:14 UTC">
+        <span class="qemu-leaderboard__rank">10</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/silicalet" target="_blank" rel="noopener noreferrer">silicalet</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="11" data-github-id="lingqian-gi" data-score="100" data-total-score="100" data-run-time="2026-05-15 15:09 UTC">
+        <span class="qemu-leaderboard__rank">11</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lingqian-gi" target="_blank" rel="noopener noreferrer">lingqian-gi</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="12" data-github-id="trace1729" data-score="100" data-total-score="100" data-run-time="2026-05-20 06:54 UTC">
+        <span class="qemu-leaderboard__rank">12</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/trace1729" target="_blank" rel="noopener noreferrer">trace1729</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="13" data-github-id="vsvnakers" data-score="100" data-total-score="100" data-run-time="2026-05-23 15:56 UTC">
+        <span class="qemu-leaderboard__rank">13</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/vsvnakers" target="_blank" rel="noopener noreferrer">vsvnakers</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="14" data-github-id="ghostdragonzero" data-score="100" data-total-score="100" data-run-time="2026-05-24 06:35 UTC">
+        <span class="qemu-leaderboard__rank">14</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ghostdragonzero" target="_blank" rel="noopener noreferrer">ghostdragonzero</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="15" data-github-id="yuanyiboyyb" data-score="100" data-total-score="100" data-run-time="2026-05-27 12:35 UTC">
+        <span class="qemu-leaderboard__rank">15</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yuanyiboyyb" target="_blank" rel="noopener noreferrer">yuanyiboyyb</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="16" data-github-id="flamboyante" data-score="100" data-total-score="100" data-run-time="2026-05-28 05:10 UTC">
+        <span class="qemu-leaderboard__rank">16</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flamboyante" target="_blank" rel="noopener noreferrer">flamboyante</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="17" data-github-id="Eclipse-Arrebol" data-score="100" data-total-score="100" data-run-time="2026-05-30 12:59 UTC">
+        <span class="qemu-leaderboard__rank">17</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Eclipse-Arrebol" target="_blank" rel="noopener noreferrer">Eclipse-Arrebol</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="18" data-github-id="csdjr" data-score="100" data-total-score="100" data-run-time="2026-06-04 16:32 UTC">
+        <span class="qemu-leaderboard__rank">18</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csdjr" target="_blank" rel="noopener noreferrer">csdjr</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="19" data-github-id="Gmikele" data-score="100" data-total-score="100" data-run-time="2026-06-10 00:16 UTC">
+        <span class="qemu-leaderboard__rank">19</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Gmikele" target="_blank" rel="noopener noreferrer">Gmikele</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="20" data-github-id="jack-wang-176" data-score="100" data-total-score="100" data-run-time="2026-06-10 13:39 UTC">
+        <span class="qemu-leaderboard__rank">20</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jack-wang-176" target="_blank" rel="noopener noreferrer">jack-wang-176</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="21" data-github-id="rhbfc" data-score="100" data-total-score="100" data-run-time="2026-06-11 06:10 UTC">
+        <span class="qemu-leaderboard__rank">21</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/rhbfc" target="_blank" rel="noopener noreferrer">rhbfc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="22" data-github-id="serf-huik" data-score="100" data-total-score="100" data-run-time="2026-06-13 03:37 UTC">
+        <span class="qemu-leaderboard__rank">22</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/serf-huik" target="_blank" rel="noopener noreferrer">serf-huik</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="23" data-github-id="dazuo233" data-score="100" data-total-score="100" data-run-time="2026-06-14 07:09 UTC">
+        <span class="qemu-leaderboard__rank">23</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dazuo233" target="_blank" rel="noopener noreferrer">dazuo233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="24" data-github-id="random25160765-collab" data-score="100" data-total-score="100" data-run-time="2026-06-15 15:10 UTC">
+        <span class="qemu-leaderboard__rank">24</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/random25160765-collab" target="_blank" rel="noopener noreferrer">random25160765-collab</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="25" data-github-id="First-da" data-score="100" data-total-score="100" data-run-time="2026-06-21 05:26 UTC">
+        <span class="qemu-leaderboard__rank">25</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/First-da" target="_blank" rel="noopener noreferrer">First-da</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="26" data-github-id="Sunuywq" data-score="100" data-total-score="100" data-run-time="2026-06-21 10:55 UTC">
+        <span class="qemu-leaderboard__rank">26</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Sunuywq" target="_blank" rel="noopener noreferrer">Sunuywq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="27" data-github-id="asdfgh870" data-score="100" data-total-score="100" data-run-time="2026-06-21 14:04 UTC">
+        <span class="qemu-leaderboard__rank">27</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/asdfgh870" target="_blank" rel="noopener noreferrer">asdfgh870</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="28" data-github-id="WhiteBearI" data-score="100" data-total-score="100" data-run-time="2026-06-23 13:38 UTC">
+        <span class="qemu-leaderboard__rank">28</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/WhiteBearI" target="_blank" rel="noopener noreferrer">WhiteBearI</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="29" data-github-id="jieniguiemmm" data-score="100" data-total-score="100" data-run-time="2026-07-02 04:06 UTC">
+        <span class="qemu-leaderboard__rank">29</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jieniguiemmm" target="_blank" rel="noopener noreferrer">jieniguiemmm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>100</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 100.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="30" data-github-id="PingGuoMiaoMiao" data-score="40" data-total-score="100" data-run-time="2026-05-02 16:42 UTC">
+        <span class="qemu-leaderboard__rank">30</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/PingGuoMiaoMiao" target="_blank" rel="noopener noreferrer">PingGuoMiaoMiao</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>40</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 40.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="31" data-github-id="flespark" data-score="40" data-total-score="100" data-run-time="2026-06-02 10:28 UTC">
+        <span class="qemu-leaderboard__rank">31</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/flespark" target="_blank" rel="noopener noreferrer">flespark</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>40</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 40.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="32" data-github-id="Lfan-ke" data-score="10" data-total-score="100" data-run-time="2026-04-15 00:55 UTC">
+        <span class="qemu-leaderboard__rank">32</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Lfan-ke" target="_blank" rel="noopener noreferrer">Lfan-ke</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="33" data-github-id="zevorn" data-score="10" data-total-score="100" data-run-time="2026-04-18 03:50 UTC">
+        <span class="qemu-leaderboard__rank">33</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/zevorn" target="_blank" rel="noopener noreferrer">zevorn</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="34" data-github-id="clsfantasy" data-score="10" data-total-score="100" data-run-time="2026-04-18 09:39 UTC">
+        <span class="qemu-leaderboard__rank">34</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/clsfantasy" target="_blank" rel="noopener noreferrer">clsfantasy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="35" data-github-id="csmyx" data-score="10" data-total-score="100" data-run-time="2026-04-18 15:58 UTC">
+        <span class="qemu-leaderboard__rank">35</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/csmyx" target="_blank" rel="noopener noreferrer">csmyx</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="36" data-github-id="coldriver-chen" data-score="10" data-total-score="100" data-run-time="2026-04-20 04:19 UTC">
+        <span class="qemu-leaderboard__rank">36</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/coldriver-chen" target="_blank" rel="noopener noreferrer">coldriver-chen</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="37" data-github-id="lickoc" data-score="10" data-total-score="100" data-run-time="2026-04-21 11:11 UTC">
+        <span class="qemu-leaderboard__rank">37</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lickoc" target="_blank" rel="noopener noreferrer">lickoc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="38" data-github-id="h1y2g3l4y5" data-score="10" data-total-score="100" data-run-time="2026-04-21 15:57 UTC">
+        <span class="qemu-leaderboard__rank">38</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/h1y2g3l4y5" target="_blank" rel="noopener noreferrer">h1y2g3l4y5</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="39" data-github-id="Altersieg" data-score="10" data-total-score="100" data-run-time="2026-04-21 19:09 UTC">
+        <span class="qemu-leaderboard__rank">39</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Altersieg" target="_blank" rel="noopener noreferrer">Altersieg</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="40" data-github-id="anicbeer" data-score="10" data-total-score="100" data-run-time="2026-04-22 13:55 UTC">
+        <span class="qemu-leaderboard__rank">40</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/anicbeer" target="_blank" rel="noopener noreferrer">anicbeer</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="41" data-github-id="Kcang-gna" data-score="10" data-total-score="100" data-run-time="2026-04-22 13:56 UTC">
+        <span class="qemu-leaderboard__rank">41</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Kcang-gna" target="_blank" rel="noopener noreferrer">Kcang-gna</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="42" data-github-id="xxluestc" data-score="10" data-total-score="100" data-run-time="2026-04-23 16:24 UTC">
+        <span class="qemu-leaderboard__rank">42</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xxluestc" target="_blank" rel="noopener noreferrer">xxluestc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="43" data-github-id="srcres258" data-score="10" data-total-score="100" data-run-time="2026-04-24 03:17 UTC">
+        <span class="qemu-leaderboard__rank">43</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srcres258" target="_blank" rel="noopener noreferrer">srcres258</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="44" data-github-id="Codeman-1999" data-score="10" data-total-score="100" data-run-time="2026-04-25 10:13 UTC">
+        <span class="qemu-leaderboard__rank">44</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Codeman-1999" target="_blank" rel="noopener noreferrer">Codeman-1999</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="45" data-github-id="mhubing" data-score="10" data-total-score="100" data-run-time="2026-04-27 01:56 UTC">
+        <span class="qemu-leaderboard__rank">45</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/mhubing" target="_blank" rel="noopener noreferrer">mhubing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="46" data-github-id="ihanzh" data-score="10" data-total-score="100" data-run-time="2026-04-27 12:01 UTC">
+        <span class="qemu-leaderboard__rank">46</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ihanzh" target="_blank" rel="noopener noreferrer">ihanzh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="47" data-github-id="adgnaf" data-score="10" data-total-score="100" data-run-time="2026-04-28 07:09 UTC">
+        <span class="qemu-leaderboard__rank">47</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/adgnaf" target="_blank" rel="noopener noreferrer">adgnaf</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="48" data-github-id="yunyi1201" data-score="10" data-total-score="100" data-run-time="2026-04-30 02:03 UTC">
+        <span class="qemu-leaderboard__rank">48</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunyi1201" target="_blank" rel="noopener noreferrer">yunyi1201</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="49" data-github-id="bbbbbq" data-score="10" data-total-score="100" data-run-time="2026-05-01 17:31 UTC">
+        <span class="qemu-leaderboard__rank">49</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/bbbbbq" target="_blank" rel="noopener noreferrer">bbbbbq</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="50" data-github-id="lusixing" data-score="10" data-total-score="100" data-run-time="2026-05-04 09:14 UTC">
+        <span class="qemu-leaderboard__rank">50</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/lusixing" target="_blank" rel="noopener noreferrer">lusixing</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="51" data-github-id="destinyFvcker" data-score="10" data-total-score="100" data-run-time="2026-05-06 14:01 UTC">
+        <span class="qemu-leaderboard__rank">51</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/destinyFvcker" target="_blank" rel="noopener noreferrer">destinyFvcker</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="52" data-github-id="73fc" data-score="10" data-total-score="100" data-run-time="2026-05-09 12:47 UTC">
+        <span class="qemu-leaderboard__rank">52</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/73fc" target="_blank" rel="noopener noreferrer">73fc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="53" data-github-id="yunjianshijie" data-score="10" data-total-score="100" data-run-time="2026-05-10 03:41 UTC">
+        <span class="qemu-leaderboard__rank">53</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yunjianshijie" target="_blank" rel="noopener noreferrer">yunjianshijie</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="54" data-github-id="scrail" data-score="10" data-total-score="100" data-run-time="2026-05-13 08:10 UTC">
+        <span class="qemu-leaderboard__rank">54</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/scrail" target="_blank" rel="noopener noreferrer">scrail</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="55" data-github-id="shengdaozm" data-score="10" data-total-score="100" data-run-time="2026-05-17 07:21 UTC">
+        <span class="qemu-leaderboard__rank">55</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/shengdaozm" target="_blank" rel="noopener noreferrer">shengdaozm</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="56" data-github-id="Firegooder" data-score="10" data-total-score="100" data-run-time="2026-05-23 06:15 UTC">
+        <span class="qemu-leaderboard__rank">56</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Firegooder" target="_blank" rel="noopener noreferrer">Firegooder</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="57" data-github-id="enlist12" data-score="10" data-total-score="100" data-run-time="2026-05-26 04:20 UTC">
+        <span class="qemu-leaderboard__rank">57</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/enlist12" target="_blank" rel="noopener noreferrer">enlist12</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="58" data-github-id="Opadc" data-score="10" data-total-score="100" data-run-time="2026-05-27 13:58 UTC">
+        <span class="qemu-leaderboard__rank">58</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Opadc" target="_blank" rel="noopener noreferrer">Opadc</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="59" data-github-id="LiuHongsGitHub" data-score="10" data-total-score="100" data-run-time="2026-05-30 10:16 UTC">
+        <span class="qemu-leaderboard__rank">59</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/LiuHongsGitHub" target="_blank" rel="noopener noreferrer">LiuHongsGitHub</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="60" data-github-id="cn-sys" data-score="10" data-total-score="100" data-run-time="2026-06-01 19:52 UTC">
+        <span class="qemu-leaderboard__rank">60</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/cn-sys" target="_blank" rel="noopener noreferrer">cn-sys</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="61" data-github-id="littlewangzai-orz" data-score="10" data-total-score="100" data-run-time="2026-06-03 16:29 UTC">
+        <span class="qemu-leaderboard__rank">61</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/littlewangzai-orz" target="_blank" rel="noopener noreferrer">littlewangzai-orz</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="62" data-github-id="2zuqisong" data-score="10" data-total-score="100" data-run-time="2026-06-05 07:16 UTC">
+        <span class="qemu-leaderboard__rank">62</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/2zuqisong" target="_blank" rel="noopener noreferrer">2zuqisong</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="63" data-github-id="srhashdh" data-score="10" data-total-score="100" data-run-time="2026-06-05 09:16 UTC">
+        <span class="qemu-leaderboard__rank">63</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/srhashdh" target="_blank" rel="noopener noreferrer">srhashdh</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="64" data-github-id="eyauwag" data-score="10" data-total-score="100" data-run-time="2026-06-07 07:33 UTC">
+        <span class="qemu-leaderboard__rank">64</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/eyauwag" target="_blank" rel="noopener noreferrer">eyauwag</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="65" data-github-id="xiaoerlang0359-debug" data-score="10" data-total-score="100" data-run-time="2026-06-07 19:05 UTC">
+        <span class="qemu-leaderboard__rank">65</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiaoerlang0359-debug" target="_blank" rel="noopener noreferrer">xiaoerlang0359-debug</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="66" data-github-id="luis-233" data-score="10" data-total-score="100" data-run-time="2026-06-08 02:24 UTC">
+        <span class="qemu-leaderboard__rank">66</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/luis-233" target="_blank" rel="noopener noreferrer">luis-233</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="67" data-github-id="jensenojs" data-score="10" data-total-score="100" data-run-time="2026-06-13 15:50 UTC">
+        <span class="qemu-leaderboard__rank">67</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/jensenojs" target="_blank" rel="noopener noreferrer">jensenojs</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="68" data-github-id="refr66" data-score="10" data-total-score="100" data-run-time="2026-06-20 10:58 UTC">
+        <span class="qemu-leaderboard__rank">68</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/refr66" target="_blank" rel="noopener noreferrer">refr66</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="69" data-github-id="yyxt-xwy" data-score="10" data-total-score="100" data-run-time="2026-06-24 08:55 UTC">
+        <span class="qemu-leaderboard__rank">69</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/yyxt-xwy" target="_blank" rel="noopener noreferrer">yyxt-xwy</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="70" data-github-id="xiex386" data-score="10" data-total-score="100" data-run-time="2026-06-27 16:19 UTC">
+        <span class="qemu-leaderboard__rank">70</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/xiex386" target="_blank" rel="noopener noreferrer">xiex386</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="71" data-github-id="dweeqhd" data-score="10" data-total-score="100" data-run-time="2026-06-29 09:33 UTC">
+        <span class="qemu-leaderboard__rank">71</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/dweeqhd" target="_blank" rel="noopener noreferrer">dweeqhd</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="72" data-github-id="litianxing2016" data-score="10" data-total-score="100" data-run-time="2026-07-02 09:36 UTC">
+        <span class="qemu-leaderboard__rank">72</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/litianxing2016" target="_blank" rel="noopener noreferrer">litianxing2016</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="73" data-github-id="Aozaki-aok0" data-score="10" data-total-score="100" data-run-time="2026-07-08 07:50 UTC">
+        <span class="qemu-leaderboard__rank">73</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/Aozaki-aok0" target="_blank" rel="noopener noreferrer">Aozaki-aok0</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+      <li class="qemu-leaderboard__row" data-rank="74" data-github-id="ovwxxwvo" data-score="10" data-total-score="100" data-run-time="2026-07-08 14:09 UTC">
+        <span class="qemu-leaderboard__rank">74</span>
+        <span class="qemu-leaderboard__name"><a href="https://github.com/ovwxxwvo" target="_blank" rel="noopener noreferrer">ovwxxwvo</a></span>
+        <span class="qemu-leaderboard__score">
+          <span><strong>10</strong><small>/100</small></span>
+          <span class="qemu-leaderboard__bar"><span style="width: 10.00%"></span></span>
+        </span>
+      </li>
+    </ol>
+  </div>
+</section>

--- a/docs/plugins/stylesheets/leaderboards.css
+++ b/docs/plugins/stylesheets/leaderboards.css
@@ -1,0 +1,286 @@
+/* QEMU camp leaderboards */
+.qemu-leaderboard-tabs {
+  border-bottom: 1px solid var(--md-default-fg-color--lightest, #e8e8e8);
+  display: flex;
+  gap: 0.25rem;
+  margin: 0 0 1rem;
+  overflow-x: auto;
+}
+
+.qemu-leaderboard-tabs__item {
+  border-bottom: 0.13rem solid transparent;
+  color: var(--md-default-fg-color);
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  font-weight: 650;
+  min-height: 2.6rem;
+  padding: 0.55rem 0.85rem 0.45rem;
+  text-decoration: none !important;
+}
+
+.qemu-leaderboard-tabs__item:hover,
+.qemu-leaderboard-tabs__item:focus-visible {
+  color: var(--md-primary-fg-color, #2196f3);
+}
+
+.qemu-leaderboard-tabs__item.is-active {
+  border-bottom-color: var(--md-primary-fg-color, #2196f3);
+  color: var(--md-primary-fg-color, #2196f3);
+}
+
+.qemu-leaderboard {
+  --leaderboard-primary: var(--md-primary-fg-color, #2196f3);
+  --leaderboard-primary-soft: rgba(33, 150, 243, 0.12);
+  --leaderboard-card: var(--md-default-bg-color, #ffffff);
+  --leaderboard-border: var(--md-default-fg-color--lightest, #e8e8e8);
+  --leaderboard-muted: var(--md-default-fg-color--light, #666666);
+  --leaderboard-row: rgba(33, 150, 243, 0.08);
+  --leaderboard-rank-column: 3.2rem;
+  --leaderboard-rank-align-width: 2.1rem;
+  --leaderboard-name-column: minmax(0, 1fr);
+  --leaderboard-score-column: minmax(5.8rem, 0.32fr);
+  background: var(--leaderboard-card);
+  border: 1px solid var(--leaderboard-border);
+  border-radius: 0.4rem;
+  box-shadow: 0 0.2rem 0.7rem rgba(0, 0, 0, 0.05);
+  margin: 1rem 0;
+  overflow: hidden;
+}
+
+.qemu-leaderboard__header {
+  align-items: center;
+  border-bottom: 1px solid var(--leaderboard-border);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.9rem 1rem;
+}
+
+.qemu-leaderboard__title {
+  color: var(--md-default-fg-color);
+  font-size: 0.95rem;
+  font-weight: 750;
+  line-height: 1.4;
+}
+
+.qemu-leaderboard__subtitle,
+.qemu-leaderboard__updated {
+  color: var(--leaderboard-muted);
+  font-size: 0.64rem;
+  line-height: 1.5;
+}
+
+.qemu-leaderboard__updated {
+  text-align: right;
+}
+
+.qemu-leaderboard__metrics {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 0.85rem 1rem 0;
+}
+
+.qemu-leaderboard__metric {
+  background: var(--leaderboard-row);
+  border-radius: 0.35rem;
+  min-height: 3.7rem;
+  padding: 0.75rem 0.85rem;
+}
+
+.qemu-leaderboard__metric--primary {
+  background: var(--leaderboard-primary);
+}
+
+.qemu-leaderboard__metric--primary .qemu-leaderboard__metric-value,
+.qemu-leaderboard__metric--primary .qemu-leaderboard__metric-label {
+  color: #ffffff;
+}
+
+.qemu-leaderboard__metric-value,
+.qemu-leaderboard__metric-label {
+  display: block;
+}
+
+.qemu-leaderboard__metric-value {
+  color: var(--md-default-fg-color);
+  font-size: 1.15rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.qemu-leaderboard__metric-label {
+  color: var(--leaderboard-muted);
+  font-size: 0.64rem;
+  line-height: 1.5;
+  margin-top: 0.35rem;
+}
+
+.qemu-leaderboard__scroll {
+  border: 1px solid var(--leaderboard-border);
+  border-radius: 0.35rem;
+  margin: 1rem;
+  max-height: 31rem;
+  overflow: auto;
+  scrollbar-gutter: stable;
+}
+
+.qemu-leaderboard__list-head,
+.qemu-leaderboard__row {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: var(--leaderboard-rank-column) var(--leaderboard-name-column) var(--leaderboard-score-column);
+}
+
+.qemu-leaderboard__list-head {
+  background: var(--leaderboard-card);
+  border-bottom: 1px solid var(--leaderboard-border);
+  color: var(--leaderboard-muted);
+  font-size: 0.62rem;
+  font-weight: 750;
+  line-height: 1.4;
+  min-width: 26rem;
+  padding: 0.55rem 0.75rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.qemu-leaderboard__list-head span:first-child {
+  justify-self: start;
+  text-align: center;
+  width: var(--leaderboard-rank-align-width);
+}
+
+.qemu-leaderboard .qemu-leaderboard__rows {
+  display: grid;
+  gap: 0;
+  list-style: none;
+  margin: 0 !important;
+  margin-inline-start: 0 !important;
+  min-width: 26rem;
+  padding: 0 !important;
+  padding-inline-start: 0 !important;
+}
+
+.qemu-leaderboard .qemu-leaderboard__row {
+  border-bottom: 1px solid var(--leaderboard-border);
+  margin: 0 !important;
+  margin-inline-start: 0 !important;
+  min-height: 2.8rem;
+  padding: 0.45rem 0.75rem;
+}
+
+.qemu-leaderboard__row:last-child {
+  border-bottom: 0;
+}
+
+.qemu-leaderboard__row--top {
+  background: linear-gradient(90deg, rgba(33, 150, 243, 0.1), transparent);
+}
+
+.qemu-leaderboard__rank {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 50%;
+  color: var(--md-default-fg-color);
+  display: inline-flex;
+  font-size: 0.68rem;
+  font-weight: 800;
+  height: 1.45rem;
+  justify-self: start;
+  justify-content: center;
+  line-height: 1;
+  margin-left: calc((var(--leaderboard-rank-align-width) - 1.45rem) / 2);
+  width: 1.45rem;
+}
+
+.qemu-leaderboard__row:nth-child(-n+3) .qemu-leaderboard__rank {
+  background: var(--md-default-fg-color);
+  color: var(--md-default-bg-color);
+}
+
+.qemu-leaderboard__name,
+.qemu-leaderboard__time {
+  color: var(--md-default-fg-color);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.qemu-leaderboard__name {
+  font-weight: 700;
+}
+
+.qemu-leaderboard__name a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.qemu-leaderboard__name a:hover,
+.qemu-leaderboard__name a:focus-visible {
+  color: var(--leaderboard-primary);
+  text-decoration: underline;
+}
+
+.qemu-leaderboard__score {
+  display: grid;
+  gap: 0.28rem;
+  min-width: 0;
+}
+
+.qemu-leaderboard__score strong {
+  color: var(--md-default-fg-color);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.qemu-leaderboard__score small {
+  color: var(--leaderboard-muted);
+  font-size: 0.62rem;
+  margin-left: 0.1rem;
+}
+
+.qemu-leaderboard__bar {
+  background: var(--leaderboard-primary-soft);
+  border-radius: 999px;
+  display: block;
+  height: 0.42rem;
+  overflow: hidden;
+}
+
+.qemu-leaderboard__bar span {
+  background: linear-gradient(90deg, var(--leaderboard-primary), #64b5f6);
+  border-radius: inherit;
+  display: block;
+  height: 100%;
+  min-width: 0.12rem;
+}
+
+.qemu-leaderboard--empty {
+  color: var(--leaderboard-muted);
+  padding: 1rem;
+}
+
+@media screen and (max-width: 52rem) {
+  .qemu-leaderboard__header {
+    align-items: flex-start;
+    display: block;
+  }
+
+  .qemu-leaderboard__updated {
+    margin-top: 0.35rem;
+    text-align: left;
+  }
+
+  .qemu-leaderboard__metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .qemu-leaderboard__scroll {
+    margin: 1rem 0.75rem;
+  }
+}

--- a/docs/plugins/stylesheets/registration-stats.css
+++ b/docs/plugins/stylesheets/registration-stats.css
@@ -1,0 +1,263 @@
+/* QEMU camp registration statistics */
+.qemu-registration-stats {
+  --registration-primary: var(--md-primary-fg-color, #2196f3);
+  --registration-primary-soft: rgba(33, 150, 243, 0.12);
+  --registration-card: var(--md-default-bg-color, #ffffff);
+  --registration-border: var(--md-default-fg-color--lightest, #e8e8e8);
+  --registration-muted: var(--md-default-fg-color--light, #666666);
+  --registration-row: rgba(33, 150, 243, 0.08);
+  background: var(--registration-card);
+  border: 1px solid var(--registration-border);
+  border-radius: 0.4rem;
+  box-shadow: 0 0.2rem 0.7rem rgba(0, 0, 0, 0.05);
+  margin: 1rem 0;
+  overflow: hidden;
+}
+
+.qemu-registration-stats__header {
+  align-items: center;
+  border-bottom: 1px solid var(--registration-border);
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.9rem 1rem;
+}
+
+.qemu-registration-stats__title {
+  color: var(--md-default-fg-color);
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.qemu-registration-stats__tabs {
+  border-bottom: 1px solid var(--registration-border);
+  display: flex;
+  gap: 0.25rem;
+  overflow-x: auto;
+  padding: 0 0.8rem;
+}
+
+.qemu-registration-stats__tab {
+  background: transparent;
+  border: 0;
+  border-bottom: 0.13rem solid transparent;
+  color: var(--md-default-fg-color);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 650;
+  min-height: 2.8rem;
+  padding: 0.55rem 0.85rem 0.45rem;
+}
+
+.qemu-registration-stats__tab:hover,
+.qemu-registration-stats__tab:focus-visible {
+  color: var(--registration-primary);
+}
+
+.qemu-registration-stats__tab:focus-visible {
+  outline: 2px solid var(--registration-primary);
+  outline-offset: -0.25rem;
+}
+
+.qemu-registration-stats__tab.is-active {
+  border-bottom-color: var(--registration-primary);
+  color: var(--registration-primary);
+}
+
+.qemu-registration-stats__metrics {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 0.85rem 1rem 0;
+}
+
+.qemu-registration-stats__metric {
+  background: var(--registration-row);
+  border-radius: 0.35rem;
+  min-height: 3.7rem;
+  padding: 0.75rem 0.85rem;
+}
+
+.qemu-registration-stats__metric--primary {
+  background: var(--registration-primary);
+}
+
+.qemu-registration-stats__metric--primary .qemu-registration-stats__metric-value,
+.qemu-registration-stats__metric--primary .qemu-registration-stats__metric-label {
+  color: #ffffff;
+}
+
+.qemu-registration-stats__metric-value,
+.qemu-registration-stats__metric-label {
+  display: block;
+}
+
+.qemu-registration-stats__metric-value {
+  color: var(--md-default-fg-color);
+  font-size: 1.15rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.qemu-registration-stats__metric-label {
+  color: var(--registration-muted);
+  font-size: 0.64rem;
+  line-height: 1.5;
+  margin-top: 0.35rem;
+}
+
+.qemu-registration-stats__body {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.9fr) minmax(13rem, 0.9fr);
+  padding: 1rem;
+}
+
+.qemu-registration-stats__chart-panel,
+.qemu-registration-stats__rank-panel {
+  min-width: 0;
+}
+
+.qemu-registration-stats__panel-title {
+  color: var(--md-default-fg-color);
+  font-size: 0.82rem;
+  font-weight: 750;
+  line-height: 1.4;
+  margin: 0 0 0.65rem;
+}
+
+.qemu-registration-stats__scroll {
+  border: 1px solid var(--registration-border);
+  border-radius: 0.35rem;
+  max-height: 27rem;
+  overflow: auto;
+  padding: 0.65rem;
+  scrollbar-gutter: stable;
+}
+
+.qemu-registration-stats__scroll--ranking {
+  padding: 0.45rem;
+}
+
+.qemu-registration-stats__bars {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.qemu-registration-stats__bar-row {
+  align-items: center;
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: minmax(7rem, 11rem) minmax(8rem, 1fr) 3.8rem;
+  min-height: 1.75rem;
+}
+
+.qemu-registration-stats__bar-label,
+.qemu-registration-stats__rank-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.qemu-registration-stats__bar-label {
+  color: var(--registration-muted);
+  font-size: 0.66rem;
+  line-height: 1.4;
+}
+
+.qemu-registration-stats__bar-track {
+  background: var(--registration-primary-soft);
+  border-radius: 999px;
+  height: 0.95rem;
+  overflow: hidden;
+}
+
+.qemu-registration-stats__bar-fill {
+  background: linear-gradient(90deg, var(--registration-primary), #64b5f6);
+  border-radius: inherit;
+  height: 100%;
+  min-width: 0.18rem;
+}
+
+.qemu-registration-stats__bar-value {
+  color: var(--md-default-fg-color);
+  font-size: 0.66rem;
+  font-weight: 650;
+  line-height: 1.4;
+  text-align: right;
+}
+
+.qemu-registration-stats__ranking {
+  display: grid;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.qemu-registration-stats__rank-row {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1.6rem minmax(0, 1fr) 3.2rem;
+  min-height: 1.9rem;
+  padding: 0.15rem 0.25rem;
+}
+
+.qemu-registration-stats__rank-index {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 50%;
+  color: var(--md-default-fg-color);
+  display: inline-flex;
+  font-size: 0.62rem;
+  font-weight: 750;
+  height: 1.25rem;
+  justify-content: center;
+  line-height: 1;
+  width: 1.25rem;
+}
+
+.qemu-registration-stats__rank-row:nth-child(-n+3) .qemu-registration-stats__rank-index {
+  background: var(--md-default-fg-color);
+  color: var(--md-default-bg-color);
+}
+
+.qemu-registration-stats__rank-name,
+.qemu-registration-stats__rank-count {
+  color: var(--md-default-fg-color);
+  font-size: 0.68rem;
+  line-height: 1.4;
+}
+
+.qemu-registration-stats__rank-count {
+  font-weight: 650;
+  text-align: right;
+}
+
+.qemu-registration-stats--error {
+  color: #d32f2f;
+  padding: 1rem;
+}
+
+@media screen and (max-width: 52rem) {
+  .qemu-registration-stats__header,
+  .qemu-registration-stats__body {
+    display: block;
+  }
+
+  .qemu-registration-stats__rank-panel {
+    margin-top: 1rem;
+  }
+
+  .qemu-registration-stats__metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .qemu-registration-stats__bar-row {
+    grid-template-columns: minmax(5.5rem, 8rem) minmax(7rem, 1fr) 3.4rem;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,8 @@ theme:
     - header.autohide
 extra_css:
   - plugins/stylesheets/extra.css
+  - plugins/stylesheets/registration-stats.css
+  - plugins/stylesheets/leaderboards.css
   - plugins/stylesheets/ppt-slides.css
 extra_javascript:
   - plugins/javascripts/toc-collapse.js

--- a/scripts/leaderboards/update_leaderboards.py
+++ b/scripts/leaderboards/update_leaderboards.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import html
 import json
 import os
 import re
@@ -18,8 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.parse import urlparse
+from urllib.parse import quote, urlencode, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 
@@ -1009,6 +1009,14 @@ def markdown_escape(value: Any) -> str:
     return text.replace("|", "\\|").replace("\n", " ")
 
 
+def html_escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def github_profile_url(github_id: str) -> str:
+    return f"https://github.com/{quote(github_id, safe='')}"
+
+
 def public_record(record: dict[str, Any]) -> dict[str, Any]:
     return {field: record[field] for field in PUBLIC_RECORD_FIELDS if field in record}
 
@@ -1077,6 +1085,115 @@ def render_direction_links(directions: list[Direction], active_key: str) -> str:
     return " | ".join(links)
 
 
+def render_direction_tabs(directions: list[Direction], active_key: str) -> str:
+    lines = ['<nav class="qemu-leaderboard-tabs" aria-label="排行榜切换">']
+    for direction in directions:
+        active = direction.key == active_key
+        class_name = "qemu-leaderboard-tabs__item is-active" if active else "qemu-leaderboard-tabs__item"
+        current = ' aria-current="page"' if active else ""
+        lines.append(
+            f'  <a class="{class_name}" href="{html_escape(direction.page)}"{current}>{html_escape(direction.title)}</a>'
+        )
+    lines.append("</nav>")
+    return "\n".join(lines)
+
+
+def format_score(value: Any) -> str:
+    try:
+        return f"{float(value):g}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def score_percent(score: Any, total_score: Any) -> float:
+    try:
+        score_value = float(score)
+        total_value = float(total_score)
+    except (TypeError, ValueError):
+        return 0.0
+    if total_value <= 0:
+        return 0.0
+    return min(max(score_value / total_value * 100, 0.0), 100.0)
+
+
+def render_leaderboard_card(
+    rows: list[dict[str, Any]],
+    direction: Direction,
+    generated_at: str | None,
+) -> str:
+    if not rows:
+        return '<div class="qemu-leaderboard qemu-leaderboard--empty">当前快照没有可展示的排名结果。</div>'
+
+    full_score_count = sum(
+        1 for row in rows if float(row["total_score"]) > 0 and float(row["score"]) >= float(row["total_score"])
+    )
+    highest = max(rows, key=lambda row: float(row["score"]))
+    highest_score = f"{format_score(highest['score'])}/{format_score(highest['total_score'])}"
+
+    lines = [
+        '<section class="qemu-leaderboard" aria-label="排行榜">',
+        '  <div class="qemu-leaderboard__header">',
+        "    <div>",
+        f'      <div class="qemu-leaderboard__title">{html_escape(direction.stage_title)} · {html_escape(direction.title)}</div>',
+        '      <div class="qemu-leaderboard__subtitle">每天刷新一次</div>',
+        "    </div>",
+        f'    <div class="qemu-leaderboard__updated">快照生成时间：{html_escape(format_time(generated_at))}</div>',
+        "  </div>",
+        '  <div class="qemu-leaderboard__metrics">',
+        '    <div class="qemu-leaderboard__metric qemu-leaderboard__metric--primary">',
+        f'      <span class="qemu-leaderboard__metric-value">{len(rows)}</span>',
+        '      <span class="qemu-leaderboard__metric-label">上榜人数</span>',
+        "    </div>",
+        '    <div class="qemu-leaderboard__metric">',
+        f'      <span class="qemu-leaderboard__metric-value">{full_score_count}</span>',
+        '      <span class="qemu-leaderboard__metric-label">满分人数</span>',
+        "    </div>",
+        '    <div class="qemu-leaderboard__metric">',
+        f'      <span class="qemu-leaderboard__metric-value">{html_escape(highest_score)}</span>',
+        '      <span class="qemu-leaderboard__metric-label">最高得分</span>',
+        "    </div>",
+        "  </div>",
+        '  <div class="qemu-leaderboard__scroll">',
+        '    <div class="qemu-leaderboard__list-head" aria-hidden="true">',
+        "      <span>排名</span>",
+        "      <span>GitHub ID</span>",
+        "      <span>得分</span>",
+        "    </div>",
+        '    <ol class="qemu-leaderboard__rows">',
+    ]
+    for row in rows:
+        rank = row["rank"]
+        github_id = str(row["github_id"])
+        score = float(row["score"])
+        total_score = float(row["total_score"])
+        run_time = format_time(row.get("run_time") or row.get("completion_time"))
+        percent = score_percent(score, total_score)
+        top_class = " qemu-leaderboard__row--top" if rank and int(rank) <= 3 else ""
+        lines.extend([
+            (
+                f'      <li class="qemu-leaderboard__row{top_class}" data-rank="{html_escape(rank)}" '
+                f'data-github-id="{html_escape(github_id)}" data-score="{format_score(score)}" '
+                f'data-total-score="{format_score(total_score)}" data-run-time="{html_escape(run_time)}">'
+            ),
+            f'        <span class="qemu-leaderboard__rank">{html_escape(rank)}</span>',
+            (
+                f'        <span class="qemu-leaderboard__name"><a href="{html_escape(github_profile_url(github_id))}" '
+                f'target="_blank" rel="noopener noreferrer">{html_escape(github_id)}</a></span>'
+            ),
+            '        <span class="qemu-leaderboard__score">',
+            f'          <span><strong>{format_score(score)}</strong><small>/{format_score(total_score)}</small></span>',
+            f'          <span class="qemu-leaderboard__bar"><span style="width: {percent:.2f}%"></span></span>',
+            "        </span>",
+            "      </li>",
+        ])
+    lines.extend([
+        "    </ol>",
+        "  </div>",
+        "</section>",
+    ])
+    return "\n".join(lines)
+
+
 def render_direction_page(
     snapshot: dict[str, Any],
     direction: Direction,
@@ -1094,34 +1211,11 @@ def render_direction_page(
     lines: list[str] = [
         f"# QEMU 训练营 2026 {direction.stage_title} {direction.title}{title_suffix}",
         "",
-        render_direction_links(directions, direction.key),
+        render_direction_tabs(directions, direction.key),
         "",
     ]
 
-    if rows:
-        lines.extend([
-            "| 排名 | GitHub ID | 得分 | 总分 | 评分 run 时间 |",
-            "| --- | --- | ---: | ---: | --- |",
-        ])
-        for row in rows:
-            github_id = markdown_escape(row["github_id"])
-            lines.append(
-                "| {rank} | {github_id} | {score:g} | {total:g} | {time} |".format(
-                    rank=row["rank"],
-                    github_id=github_id,
-                    score=float(row["score"]),
-                    total=float(row["total_score"]),
-                    time=format_time(row.get("run_time") or row.get("completion_time")),
-                )
-            )
-    else:
-        lines.append("当前快照没有可展示的排名结果。")
-
-    lines.extend([
-        "",
-        f"每天刷新一次｜快照生成时间：{format_time(metadata.get('generated_at'))}",
-    ])
-
+    lines.append(render_leaderboard_card(rows, direction, metadata.get("generated_at")))
     lines.append("")
     text = "\n".join(lines)
     (output_dir / direction.page).write_text(text, encoding="utf-8")
@@ -1164,6 +1258,54 @@ def parse_score(value: str) -> float | None:
         return None
 
 
+LEADERBOARD_ROW_RE = re.compile(
+    r'<li class="qemu-leaderboard__row[^"]*"'
+    r'[^>]*data-rank="(?P<rank>[^"]*)"'
+    r'[^>]*data-github-id="(?P<github_id>[^"]*)"'
+    r'[^>]*data-score="(?P<score>[^"]*)"'
+    r'[^>]*data-total-score="(?P<total_score>[^"]*)"'
+    r'[^>]*data-run-time="(?P<run_time>[^"]*)"',
+    re.S,
+)
+
+
+def parse_rank(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def rendered_page_generated_at(page_text: str) -> str:
+    generated_match = re.search(r"快照生成时间：\s*([^<\n]+)", page_text)
+    if not generated_match:
+        return ""
+    parsed = parse_time(generated_match.group(1).strip())
+    if parsed == datetime.max.replace(tzinfo=timezone.utc):
+        return ""
+    return parsed.isoformat().replace("+00:00", "Z")
+
+
+def rendered_page_html_rows(page_text: str, direction: Direction) -> list[dict[str, Any]]:
+    ranked: list[dict[str, Any]] = []
+    for match in LEADERBOARD_ROW_RE.finditer(page_text):
+        score = parse_score(html.unescape(match.group("score")))
+        total_score = parse_score(html.unescape(match.group("total_score")))
+        if score is None or total_score is None:
+            continue
+        ranked.append({
+            "stage": direction.stage,
+            "direction": direction.key,
+            "rank": parse_rank(html.unescape(match.group("rank"))),
+            "github_id": html.unescape(match.group("github_id")),
+            "score": score,
+            "total_score": total_score,
+            "run_time": html.unescape(match.group("run_time")),
+            "completion_time": "",
+        })
+    return ranked
+
+
 def load_snapshot_from_rendered_pages(config: dict[str, Any], root: Path) -> dict[str, Any] | None:
     ranked: list[dict[str, Any]] = []
     generated_at = ""
@@ -1173,7 +1315,14 @@ def load_snapshot_from_rendered_pages(config: dict[str, Any], root: Path) -> dic
             page = output_dir / direction.page
             if not page.exists():
                 continue
-            for line in page.read_text(encoding="utf-8").splitlines():
+            page_text = page.read_text(encoding="utf-8")
+            if not generated_at:
+                generated_at = rendered_page_generated_at(page_text)
+            html_rows = rendered_page_html_rows(page_text, direction)
+            if html_rows:
+                ranked.extend(html_rows)
+                continue
+            for line in page_text.splitlines():
                 if line.startswith("每天刷新一次｜快照生成时间：") and not generated_at:
                     display_time = line.split("：", 1)[1].strip()
                     parsed = parse_time(display_time)
@@ -1188,14 +1337,10 @@ def load_snapshot_from_rendered_pages(config: dict[str, Any], root: Path) -> dic
                 total_score = parse_score(columns[3])
                 if score is None or total_score is None:
                     continue
-                try:
-                    rank = int(columns[0])
-                except ValueError:
-                    rank = None
                 ranked.append({
                     "stage": direction.stage,
                     "direction": direction.key,
-                    "rank": rank,
+                    "rank": parse_rank(columns[0]),
                     "github_id": columns[1],
                     "score": score,
                     "total_score": total_score,
@@ -1603,9 +1748,17 @@ def self_test() -> None:
         changed_content["ranked"][0]["score"] = float(changed_content["ranked"][0]["score"]) + 1
         assert leaderboard_content_changed(changed_content, public)
         page = (root / "pages" / "cpu.md").read_text(encoding="utf-8")
-        assert "qemu-camp-2026-exper" not in page.split("| GitHub ID |", 1)[-1]
+        assert "qemu-camp-2026-exper" not in page
         assert "bob" in page and "alice" in page
-        assert "每天刷新一次｜快照生成时间：" in page
+        assert "qemu-leaderboard" in page
+        assert "快照生成时间：" in page
+        assert "qemu-leaderboard__list-head" in page
+        assert "<span>排名</span>" in page
+        assert "<span>GitHub ID</span>" in page
+        assert "<span>得分</span>" in page
+        assert "评分 run 时间" not in page
+        assert "qemu-leaderboard__score" in page
+        assert "data-score=" in page and "data-run-time=" in page
         rendered_snapshot = load_snapshot_from_rendered_pages(config, root)
         assert rendered_snapshot is not None
         assert {item["github_id"] for item in rendered_snapshot["ranked"]} == {"alice", "bob"}


### PR DESCRIPTION
## Summary

- Render 2026 leaderboard pages with a card/list UI and remove the visible table header, score column, and run-time column.
- Keep `data-*` fields in generated leaderboard rows so the update script can still parse existing rendered pages as a snapshot source.
- Link GitHub IDs to their GitHub profile pages.
- Add standalone CSS files for leaderboard and registration stats components so deployed pages do not depend on stale bundled `extra.css` cache.
- Update the home page latest news block to use the latest news item from 2026-07-03.

## Validation

- `make build`
- `python3 scripts/leaderboards/update_leaderboards.py --self-test`
- `make lint`
- `make mdlint`
- `git diff --check`
- Verified rendered leaderboard pages can still be parsed back into 425 records.