### PR TITLE
ci: pause scheduled leaderboard updates

### DIFF
--- a/.github/workflows/leaderboards.yml
+++ b/.github/workflows/leaderboards.yml
@@ -1,8 +1,6 @@
 name: Update Leaderboards
 
 on:
-  schedule:
-    - cron: '20 18 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- remove the scheduled trigger from the Update Leaderboards workflow
- keep `workflow_dispatch` available for manual runs

## Why

The scheduled leaderboard run failed after GitHub's Contents API returned repeated 502 responses during centralized collection. Pause automatic runs while the score publishing flow is redesigned.

Failed run: https://github.com/gevico/qemu-camp-tutorial/actions/runs/29046864077/job/86217577044

## Impact

Leaderboards will no longer refresh automatically each day. Maintainers can still start the workflow manually when needed.

## Follow-up

Move score publishing to the training repositories: after their scoring Actions complete, they should open score update pull requests against the online tutorial repository instead of relying on centralized polling.

## Validation

- parsed `.github/workflows/leaderboards.yml` with Ruby's YAML parser
- ran `git diff --check`
