### PR TITLE
docs/blogs: add stage1 summary by ovwxxwvo

### DIFF
--- a/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/02_gpio-i2c.md
+++ b/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/02_gpio-i2c.md
@@ -46,10 +46,8 @@
 ./rust/hw/i2c/gpio_i2c/Cargo.toml   // 注意依赖相对路径层级  
 ```  
 
-- `./rust/Cargo.toml`顶层`workspace`添加相应的`crate`，  
-  这样lsp才能生效，必要时`cargo clean`。  
-- `./rust/hw/i2c/gpio_i2c/meson.build`文件中`_gpio_i2c_rs`需要添加  
-  `{'.': _gpio_i2c_bindings_inc_rs},` 。  
+- `./rust/Cargo.toml`顶层`workspace`添加相应的`crate`，这样lsp才能生效，必要时`cargo clean`。  
+- `./rust/hw/i2c/gpio_i2c/meson.build`文件中`_gpio_i2c_rs`需要添加`{'.': _gpio_i2c_bindings_inc_rs},` 。  
 
 ### 🛠️ 项目混合编程对接文件  
 ```  

--- a/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/02_gpio-i2c.md
+++ b/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/02_gpio-i2c.md
@@ -28,9 +28,9 @@
 ```  
 
 - 项目文件结构的设计是为了减少QEMU的C代码对RUST代码的多次调用。  
-- 主控设备实现的crate(gpio_i2c)是唯一提供给QEMU调用的接口，每个主控都是独立的crate。  
-- 主控总线和从机特性的实现的crate(i2c_core)仅在RUST内部供主控和从机的实现使用。  
-- 从机外设的实现将在crate(i2c_slave)以mod形式存在，每个从机外设都为独立的mod。  
+- 主控设备实现的crate(`gpio_i2c`)是唯一提供给QEMU调用的接口，每个主控都是独立的crate。  
+- 主控总线和从机特性的实现的crate(`i2c_core`)仅在RUST内部供主控和从机的实现使用。  
+- 从机外设的实现将在crate(`i2c_slave`)以mod形式存在，每个从机外设都为独立的mod。  
 
 ### 🛠️ 项目构建所需修改文件  
 ```  
@@ -135,11 +135,12 @@ processor                 controller                   peripheral
 ```  
 ```  
    /-SDA-<->- start+[7addr+1rw](tx)+n|ack(rx)+[8data](tx)+n|ack(rx)+stop -<->-SDA-\  
-I2C device                                                                    I2C controller  
+I2C peripheral                                                                I2C controller  
    \-SCL----- ------            ...12345678...123456789...         ----- -----SCL-/  
 ```  
 
 - I2C协议，两线一时钟(SCL)一数据(SDA)，单线进行数据收发。  
+- 主控选择哪个从机通信，依靠传输数据包内的设备地址，有独立地址寄存器。  
 - 启停信号由主控写控制寄存器触发，不作保存。  
 - 应答信号由字节接收方发起，应答判定结果保存在状态寄存器。  
 - 7位地址+1位读写标记，构成8位保存在地址寄存器，由主控发起。  
@@ -154,11 +155,11 @@ pub struct I2CBus {
 }  
 
 impl I2CBus {  
-    pub fn new             // 创建I2C总线，初始化设备列表及当前寻址地址  
-    pub fn device_count    // 统计I2C总线上挂载的从设备数量  
+    pub fn new             // 创建总线，初始化设备列表及当前寻址地址  
+    pub fn device_count    // 统计总线上挂载的从设备数量  
     pub fn is_busy         // 判断总线是否正在传输  
 
-    pub fn attach          // 挂载I2C从机到I2C总线  
+    pub fn attach          // 挂载从机到总线  
     pub fn start_transfer  // 返回开始信号，保存地址，确定主机读写  
     pub fn end_transfer    // 返回结束信号，设置地址为空  
     pub fn send            // 发送数据，调用从机发送函数  
@@ -172,10 +173,10 @@ impl I2CBus {
 ### 🧩 I2C_SLAVE的实现框架  
 ```  
 pub struct AT24C02Slave {  
-    pub addr: u8,          // 从机设备地址  
-    pub regs: [u8; 256],   // EEPROM存储数组  
-    pub pointer: u8,       // 存储读写指针  
-    pub first_byte: bool,  // 标记首字节  
+    pub addr      : u8,         // 从机设备地址  
+    pub regs      : [u8; 256],  // EEPROM存储数组  
+    pub pointer   : u8,         // 存储读写指针  
+    pub first_byte: bool,       // 标记首字节  
 }  
 
 impl I2CSlave for AT24C02Slave {  
@@ -201,6 +202,8 @@ impl GPIOI2CRegisters {
         match offset {  
             ADDR     => self.addr     = Addr::from(value),  
             DATA     => self.data     = value,  
+
+        // I2C主从数据传输由写控制寄存器触发，需实现5个逻辑分支：  
             CTRL     => {  
                 let mut i2c_bus = device.i2c_bus.borrow_mut();  
                 let mut ctrl = Ctrl::from(value);  

--- a/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/03_rust-spi.md
+++ b/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/03_rust-spi.md
@@ -47,8 +47,7 @@
 ```  
 
 - `./rust/Cargo.toml`顶层`workspace`添加相应的`crate`，这样lsp才能生效，必要时`cargo clean`。  
-- `./rust/hw/ssi/rust_spi/meson.build`文件中`_rust_spi_rs`需要添加  
-  `{'.': _rust_spi_bindings_inc_rs},` 。  
+- `./rust/hw/ssi/rust_spi/meson.build`文件中`_rust_spi_rs`需要添加`{'.': _rust_spi_bindings_inc_rs},` 。  
 
 ### 🛠️ 项目混合编程对接文件  
 ```  

--- a/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/03_rust-spi.md
+++ b/docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/03_rust-spi.md
@@ -28,9 +28,9 @@
 ```  
 
 - 项目文件结构的设计是为了减少QEMU的C代码对RUST代码的多次调用。  
-- 主控设备实现的crate(rust_spi)是唯一提供给QEMU调用的接口，每个主控都是独立的crate。  
-- 主控总线和从机特性的实现的crate(ssi_core)仅在RUST内部供主控和从机的实现使用。  
-- 从机外设的实现将在crate(ssi_slave)以mod形式存在，每个从机外设都为独立的mod。  
+- 主控设备实现的crate(`rust_spi`)是唯一提供给QEMU调用的接口，每个主控都是独立的crate。  
+- 主控总线和从机特性的实现的crate(`ssi_core`)仅在RUST内部供主控和从机的实现使用。  
+- 从机外设的实现将在crate(`ssi_slave`)以mod形式存在，每个从机外设都为独立的mod。  
 
 ### 🛠️ 项目构建所需修改文件  
 ```  
@@ -46,8 +46,7 @@
 ./rust/hw/ssi/rust_spi/Cargo.toml   // 注意依赖相对路径层级  
 ```  
 
-- `./rust/Cargo.toml`顶层`workspace`添加相应的`crate`，  
-  这样lsp才能生效，必要时`cargo clean`。  
+- `./rust/Cargo.toml`顶层`workspace`添加相应的`crate`，这样lsp才能生效，必要时`cargo clean`。  
 - `./rust/hw/ssi/rust_spi/meson.build`文件中`_rust_spi_rs`需要添加  
   `{'.': _rust_spi_bindings_inc_rs},` 。  
 
@@ -123,62 +122,67 @@ qtest_writel -> RUSTSPI_OPS.write -> RUSTSPIState::write -> RUSTSPIRegisters::wr
 - `RUSTSPIState::init`初始化由`RUSTSPIState::new`构造间接调用。  
 - `RUSTSPIState::realize`实体化由`RUSTSPIState::sysbus_realize`实现间接调用。  
 - `SSIBus`分别在`RUSTSPIState`的`init`和`realize`中进行创建和从机挂载。  
-- SSI主从数据传输仅由写控制寄存器触发，写入其余寄存器和读取所有寄存器不触发总线通信。  
+- SSI主从数据传输仅由写数据寄存器触发，写入其余寄存器和读取所有寄存器不触发总线通信。  
 
 ---  
 
 ### 🔄 SSI协议数据流转  
 ```  
              sys-bus                      ssi-bus  
- risc-v --<----------->-- ssi-master --<----------->-- ssi-slave  
+ risc-v --<----------->-- spi-master --<----------->-- ssi-slave  
 processor                 controller                   peripheral  
 ```  
 ```  
-  /--MOSI-<-- 8addr+8data+8data+... --<-MOSI--\  
- / /-MISO->-- 8addr+8data+8data+... -->-MISO-\ \  
-SPI device                                SPI controller  
- \ \-SCLK---- .12345678...12345678. ----Sclk-/ /  
-  \---CS-----      NCS|NSS(CS)      -----CS---/  
+    /--MOSI-<-- 8addr+8data+8data+... --<-MOSI--\  
+   / /-MISO->-- 8addr+8data+8data+... -->-MISO-\ \  
+SPI peripheral                            SPI controller  
+   \ \-SCLK---- .12345678...12345678. ----SCLK-/ /  
+    \---CS-----      NCS|NSS(CS)      -----CS---/  
 ```  
 
-- SSI协议，两线一时钟(SCL)一数据(SDA)，单线进行数据收发。  
+- SSI协议，四线，片选(CS)、时钟(SCLK)、主出从入(MOSI)、主入从出(MISO)，两线双向数据收发。  
+- 主控选择哪个从机通信，依靠独立片选硬件引脚，有独立的片选寄存器。  
+- 数据包中的8位数据地址为从机外设存储偏移地址。  
+- 协议没有启停信号、应答位、读写标记，四线通信逻辑实现更加简单。  
 
 ### 🧩 SSI_BUS的实现框架  
 ```  
 pub struct SSIBus {  
-    devices: Vec<Box<dyn SSISlave>>,  
-    current_cs: u8,  
+    devices: Vec<Box<dyn SSISlave>>,  // 挂载的从机列表  
+    current_cs: u8,                   // 当前选中片选编号  
 }  
 
 impl SSIBus {  
-    pub fn new() -> Self {  
-    pub fn device_count(&self) -> usize {  
+    pub fn new           // 创建总线，初始化设备列表及当前片选编号  
+    pub fn device_count  // 统计总线上挂载的从设备数量  
 
-    pub fn attach(&mut self, device: Box<dyn SSISlave> ) {  
-    pub fn chip_select(&mut self, new_cs: u8) {  
-    pub fn transfer(&mut self, val: u8) -> u8 {  
+    pub fn attach        // 挂载从机到总线  
+    pub fn chip_select   // 切换片选信号  
+    pub fn transfer      // 完成数据收发传输  
 }  
 ```  
+- 未作总线事件分层抽象，数据收发逻辑统一封装在单一传输函数，有待优化。  
 
 ### 🧩 SSI_SLAVE的实现框架  
 ```  
 pub struct AT25Slave {  
-    pub cs_id   : u8,  
-    pub regs    : [u8; 256],  
-    pub pointer : u8,  
-    pub is_addr : bool,  
-    pub is_write: bool,  
-    pub is_read : bool,  
-    pub sr      : u8,  
-    pub send_sr : bool,  
+    pub cs_id   : u8,         // 绑定的片选编号  
+    pub regs    : [u8; 256],  // 256字节模拟存储区  
+    pub pointer : u8,         // 内部读写地址指针  
+    pub is_addr : bool,       // 标记当前字节为地址  
+    pub is_write: bool,       // 写操作使能标记  
+    pub is_read : bool,       // 读操作使能标记  
+    pub sr      : u8,         // 设备状态寄存器  
+    pub send_sr : bool,       // 标记是否输出状态寄存器  
 }  
 
 impl SSISlave for AT25Slave {  
-    fn cs_id(&self) -> u8 {  
-    fn set_cs(&mut self, _select: bool){  
-    fn transfer(&mut self, data: u8) -> u8 {  
+    fn cs_id     // 返回自身片选ID  
+    fn set_cs    // 片选选中/取消选中处理  
+    fn transfer  // 单字节数据收发处理  
 }  
 ```  
+- 未作总线事件回调机制，只能依靠新增结构体字段，有待完善。  
 
 ---  
 
@@ -192,6 +196,8 @@ impl RUSTSPIRegisters {
     pub(self) fn write(&mut self, offset: RegisterOffset, value: u32, device: &RUSTSPIState) -> bool {  
         use RegisterOffset::*;  
         match offset {  
+
+        // 写控制寄存器，负责配置、使能，并设置相关标志。  
             CR1 => {  
                 // let mut cr1 = Cr1::from(value);  
                 let cr1 = Cr1::from(value);  
@@ -208,11 +214,15 @@ impl RUSTSPIRegisters {
                 };  
                 self.cr1 = cr1  
             },  
+
+        // 写片选寄存器，负责切换片选信号。  
             CS  => {  
                 let mut ssi_bus = device.ssi_bus.borrow_mut();  
                 ssi_bus.chip_select(value as u8);  
                 self.cs = value;  
             },  
+
+        // SSI主从数据传输由写数据寄存器触发，并设置发送缓存为空和接收缓存非空的状态标志。  
             DR  => {  
                 let tx_byte = value as u8;  
                 let mut ssi_bus = device.ssi_bus.borrow_mut();  
@@ -228,7 +238,10 @@ impl RUSTSPIRegisters {
 
 }  
 ```  
-- SSI主从数据传输由写控制寄存器触发，需实现5个逻辑分支：  
+
+- SSI主从数据传输由写数据寄存器触发，并设置发送缓存为空和接收缓存非空的状态标志。  
+- 写控制寄存器，负责配置、使能，并设置相关标志。  
+- 写片选寄存器，负责切换片选信号。  
 
 ---  
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -284,7 +284,7 @@ nav:
         - ovwxxwvo:
           - RUST实验 i2c-bus:  blogs/2026/professional/qemu-camp-2026-ovwxxwvo/01_i2c-bus.md
           - RUST实验 gpio-i2c: blogs/2026/professional/qemu-camp-2026-ovwxxwvo/02_gpio-i2c.md
-          # - RUST实验 rust-spi: blogs/2026/professional/qemu-camp-2026-ovwxxwvo/03_rust-spi.md
+          - RUST实验 rust-spi: blogs/2026/professional/qemu-camp-2026-ovwxxwvo/03_rust-spi.md
       - 项目阶段:
         - 暂无文章: blogs/2026/project/project-stage.md
     - 训练营 2025:


### PR DESCRIPTION
## 关联章节/文件

- docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/01_i2c-bus.md
- docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/02_gpio-i2c.md
- docs/blogs/2026/professional/qemu-camp-2026-ovwxxwvo/03_rust-spi.md


## 修改类型

- [x] 内容补充
- [ ] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述
提交专业阶段完成的博客

## 本地验证
<!-- 请确保您已在本地完成以下检查 -->
- [x] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [x] 已执行 `zensical serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观
