### PR TITLE
ci/docs: update repository identity for qemu-camp

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ make help
 
 ## 维护团队​
 
-- 发起组织：[格维开源社区](https://github.com/gevico)
+- 发起组织：[格维开源社区](https://github.com/qemu-camp)
 
-- 核心维护团队：[QEMU 训练营项目组](https://github.com/gevico/qemu-training-camp)
+- 核心维护团队：[QEMU 训练营项目组](https://github.com/qemu-camp)
 
 - 社群支持：[QEMU 训练营 QQ 群](https://qm.qq.com/q/DxIhHgpItM)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: QEMU Training Camp
 site_author: GTOC
-site_url: https://github.com/gevico
-repo_name: gevico/qemu-camp-tutorial
-repo_url: https://github.com/gevico/qemu-camp-tutorial
-copyright: Brought to you by <a href="https://github.com/gevico">Gevico Tech Open Community</a>. Available freely under the MIT license.
+site_url: https://qemu.gevico.online
+repo_name: qemu-camp/qemu-camp-tutorial
+repo_url: https://github.com/qemu-camp/qemu-camp-tutorial
+copyright: Brought to you by <a href="https://github.com/qemu-camp">Gevico Tech Open Community</a>. Available freely under the MIT license.
 
 plugins:
   - md-preview:

--- a/scripts/leaderboards/config.json
+++ b/scripts/leaderboards/config.json
@@ -1,5 +1,5 @@
 {
-    "organization": "gevico",
+    "organization": "qemu-camp",
     "max_runs_per_repo": 6,
     "workers": 4,
     "max_diagnostics_per_page": 40,


### PR DESCRIPTION
## 关联章节/文件

- 配置文件：`mkdocs.yml`
- 项目主页：`README.md`
- 排行榜采集配置：`scripts/leaderboards/config.json`

## 修改类型

- [ ] 内容补充
- [ ] 错别字/语句修正
- [x] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [x] 其他：仓库迁移后的 GitHub Pages 和 GitHub 组织链接修复

## 修改描述

- 修复 Actions run [31434071831](https://github.com/qemu-camp/qemu-camp-tutorial/actions/runs/31434071831) 中 Pages 部署因旧组织 `gevico` 导致的身份不匹配问题。
- 将站点正式地址更新为 `https://qemu.gevico.online`。
- 将 MkDocs 右上角仓库名称和链接更新为 `qemu-camp/qemu-camp-tutorial`。
- 将项目主页的维护组织链接从旧地址更新为 `qemu-camp`。
- 将排行榜采集目标组织更新为 `qemu-camp`。

## 本地验证

- [x] 已执行 `make lint`
- [x] 已执行 `make mdlint`
- [x] 已执行 `make build`
- [x] 已执行 `python3 scripts/leaderboards/update_leaderboards.py --self-test`

## 附加说明

失败 job 的根因是仓库迁移后 Actions 运行上下文仍引用旧组织；本次提交清理仓库内运行时和站点元数据中的旧组织标识。