### PR TITLE
docs: rename site to QEMU Camp 2026

### DIFF
--- a/docs/config/current-camp.json
+++ b/docs/config/current-camp.json
@@ -1,5 +1,5 @@
 {
-  "program_name": "QEMU Training Camp",
+  "program_name": "QEMU Camp 2026",
   "current_year": 2026,
   "available_years": [2025, 2026, 2027],
   "api_base": "https://api.qemu.gevico.online"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# QEMU Training Camp
+# QEMU Camp 2026
 
 <style>
 body:has(.home-page) .md-main__inner {
@@ -545,7 +545,7 @@ body:has(.home-page) .md-content__inner > h1:first-child {
   <section class="home-hero">
     <img class="home-hero__image" src="image/qemu-camp-hero-bg.png" alt="QEMU 训练营科技渐变背景" />
     <div class="home-hero__content">
-      <span class="home-eyebrow">QEMU Training Camp</span>
+      <span class="home-eyebrow">QEMU Camp 2026</span>
       <p class="home-hero__title">QEMU 训练营 2026</p>
       <p class="home-hero__desc">以模拟器/虚拟化技术为底座的 CPU/GPGPU 体系结构相关的开放学习与实践平台，全程免费，资料开源，社区共建。</p>
       <div class="home-hero__actions">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: QEMU Training Camp
+site_name: QEMU Camp 2026
 site_author: GTOC
 site_url: https://qemu.gevico.online
 repo_name: qemu-camp/qemu-camp-tutorial


### PR DESCRIPTION
## 关联章节/文件

- 站点配置：`mkdocs.yml`
- 项目主页：`docs/index.md`
- 当前训练营配置：`docs/config/current-camp.json`

## 修改类型

- [x] 内容补充
- [ ] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [x] 其他：站点名称统一

## 修改描述

将站点中展示和配置的 `QEMU Training Camp` 统一更新为 `QEMU Camp 2026`，覆盖站点标题、主页标题与当前训练营名称。

## 本地验证

- [x] 已执行 `make lint`
- [x] 已执行 `make mdlint`
- [x] 已执行 `make build`
- [x] 已确认仓库中不再残留旧标题。