### PR TITLE
docs: simplify displayed repository name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: QEMU Camp 2026
 site_author: GTOC
 site_url: https://qemu.gevico.online
-repo_name: qemu-camp/qemu-camp-tutorial
+repo_name: qemu-camp-tutorial
 repo_url: https://github.com/qemu-camp/qemu-camp-tutorial
 copyright: Brought to you by <a href="https://github.com/qemu-camp">Gevico Tech Open Community</a>. Available freely under the MIT license.
 


### PR DESCRIPTION
## 关联章节/文件

- 站点配置：`mkdocs.yml`

## 修改类型

- [x] 格式调整
- [x] 其他：更新仓库展示名称

## 修改描述

将 MkDocs 右上角显示的仓库名称从 `qemu-camp/qemu-camp-tutorial` 简化为 `qemu-camp-tutorial`，仓库链接保持为 `https://github.com/qemu-camp/qemu-camp-tutorial`。

## 本地验证

- [x] 已执行 `make lint`
- [x] 已执行 `make build`
- [x] 已确认生成页面展示 `qemu-camp-tutorial`。