### PR TITLE
docs: update AI Infra branding and logo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -717,7 +717,7 @@ body:has(.home-page) .md-content__inner > h1:first-child {
   <section class="home-section home-about">
     <div>
       <h2>关于 QEMU 训练营</h2>
-      <p>QEMU 训练营是在清华大学陈渝老师团队的倡议下，由格维开源社区发起，并与华中科技大学开放原子俱乐部联合主办的公益性技术训练营，旨在搭建一个以模拟器/虚拟化技术为底座的 AI Infra 学习与实践平台，全程免费，资料开源，社区共建。</p>
+      <p>QEMU 训练营由格维开源社区与华中科技大学开放原子俱乐部联合主办，最初由清华大学陈渝老师团队提出倡议，旨在搭建一个以模拟器/虚拟化技术为底座的 AI Infra 学习与实践平台。训练营全程免费，资料开源，社区共建。</p>
     </div>
     <div class="home-about__meta">
       <span>发起组织：格维开源社区</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -547,7 +547,7 @@ body:has(.home-page) .md-content__inner > h1:first-child {
     <div class="home-hero__content">
       <span class="home-eyebrow">QEMU Camp 2026</span>
       <p class="home-hero__title">QEMU 训练营 2026</p>
-      <p class="home-hero__desc">以模拟器/虚拟化技术为底座的 CPU/GPGPU 体系结构相关的开放学习与实践平台，全程免费，资料开源，社区共建。</p>
+      <p class="home-hero__desc">以模拟器/虚拟化技术为底座的 AI Infra 学习与实践平台，全程免费，资料开源，社区共建。</p>
       <div class="home-hero__actions">
         <a class="home-button home-button--primary" href="tutorial/2026/">开始学习</a>
         <a class="home-button" href="enroll/">GitHub 报名</a>
@@ -717,7 +717,7 @@ body:has(.home-page) .md-content__inner > h1:first-child {
   <section class="home-section home-about">
     <div>
       <h2>关于 QEMU 训练营</h2>
-      <p>QEMU 训练营是在清华大学陈渝老师团队的倡议下，由格维开源社区发起，并与华中科技大学开放原子俱乐部联合主办的公益性技术训练营，旨在搭建一个以模拟器/虚拟化技术为底座的 CPU/GPGPU 体系结构相关的开放学习与实践平台，全程免费，资料开源，社区共建。</p>
+      <p>QEMU 训练营是在清华大学陈渝老师团队的倡议下，由格维开源社区发起，并与华中科技大学开放原子俱乐部联合主办的公益性技术训练营，旨在搭建一个以模拟器/虚拟化技术为底座的 AI Infra 学习与实践平台，全程免费，资料开源，社区共建。</p>
     </div>
     <div class="home-about__meta">
       <span>发起组织：格维开源社区</span>

--- a/docs/tutorial/2026/index.md
+++ b/docs/tutorial/2026/index.md
@@ -2,7 +2,7 @@
 
 !!! tip "训练营介绍"
 
-    QEMU 训练营是在清华大学陈渝老师团队的倡议下，由[格维开源社区][gevico-link]发起，并与[华中科技大学开放原子开源俱乐部][hust-openatom-club-link]联合主办的公益性技术训练营，旨在搭建一个以模拟器/虚拟化技术为底座的 CPU/GPGPU 体系结构相关的开放学习与实践平台，全程免费，资料开源，社区共建。本期 QEMU 训练营（2026）合作单位有 [腾讯云 CNB 社区][cnb-link]、[甲辰计划][rv2036-link]、[开源操作系统社区][os2edu-link]、[苦芽科技][kubuds-link]、[沐曦][metax-link]、[OpenCamp 社区][opencamp-link]、[Kendryte 勘智][kendryte-link]、Zett.ai。
+    QEMU 训练营是在清华大学陈渝老师团队的倡议下，由[格维开源社区][gevico-link]发起，并与[华中科技大学开放原子开源俱乐部][hust-openatom-club-link]联合主办的公益性技术训练营，旨在搭建一个以模拟器/虚拟化技术为底座的 AI Infra 学习与实践平台，全程免费，资料开源，社区共建。本期 QEMU 训练营（2026）合作单位有 [腾讯云 CNB 社区][cnb-link]、[甲辰计划][rv2036-link]、[开源操作系统社区][os2edu-link]、[苦芽科技][kubuds-link]、[沐曦][metax-link]、[OpenCamp 社区][opencamp-link]、[Kendryte 勘智][kendryte-link]、Zett.ai。
 
 [☞ 线上报名通道 ☄](https://opencamp.cn/gevico/camp/2026/register?code=d6EdXAxro0eFJ)
 

--- a/docs/tutorial/2026/index.md
+++ b/docs/tutorial/2026/index.md
@@ -2,7 +2,7 @@
 
 !!! tip "训练营介绍"
 
-    QEMU 训练营是在清华大学陈渝老师团队的倡议下，由[格维开源社区][gevico-link]发起，并与[华中科技大学开放原子开源俱乐部][hust-openatom-club-link]联合主办的公益性技术训练营，旨在搭建一个以模拟器/虚拟化技术为底座的 AI Infra 学习与实践平台，全程免费，资料开源，社区共建。本期 QEMU 训练营（2026）合作单位有 [腾讯云 CNB 社区][cnb-link]、[甲辰计划][rv2036-link]、[开源操作系统社区][os2edu-link]、[苦芽科技][kubuds-link]、[沐曦][metax-link]、[OpenCamp 社区][opencamp-link]、[Kendryte 勘智][kendryte-link]、Zett.ai。
+    QEMU 训练营由[格维开源社区][gevico-link]与[华中科技大学开放原子俱乐部][hust-openatom-club-link]联合主办，最初由清华大学陈渝老师团队提出倡议，旨在搭建一个以模拟器/虚拟化技术为底座的 AI Infra 学习与实践平台。训练营全程免费，资料开源，社区共建。本期 QEMU 训练营（2026）合作单位有 [腾讯云 CNB 社区][cnb-link]、[甲辰计划][rv2036-link]、[开源操作系统社区][os2edu-link]、[苦芽科技][kubuds-link]、[沐曦][metax-link]、[OpenCamp 社区][opencamp-link]、[Kendryte 勘智][kendryte-link]、Zett.ai。
 
 [☞ 线上报名通道 ☄](https://opencamp.cn/gevico/camp/2026/register?code=d6EdXAxro0eFJ)
 


### PR DESCRIPTION
## Summary

- 将主页和 2026 训练营介绍更新为 AI Infra 学习与实践平台。
- 使用 qemu-book 封面中的二次设计 Q + 鸟形剪影作为站点 logo。
- Logo 为深蓝方形头像，移除了 EMU、中文书名和装饰线，并保留 GitHub 圆形裁切安全区。

## Validation

- `make lint`
- `make mdlint`
- `make build`